### PR TITLE
Fix vercel static deploy path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,11 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "builds": [],
+  "builds": [
+    { "src": "index.html", "use": "@vercel/static" }
+  ],
   "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
-  ]
+    { "src": "/(.*)", "dest": "/index.html" }
+  ],
+  "outputDirectory": "."
 }


### PR DESCRIPTION
## Summary
- update `vercel.json` to match Vercel static output requirements

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853f0feb4e48324ae2f2c01e3c81ec0