### PR TITLE
Fix login personalization and balance loading

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -6392,7 +6392,7 @@ function stopVerificationProgress() {
           const balanceData = JSON.parse(savedBalance);
           
           // Verificar si este es el dispositivo correcto
-          if (balanceData.deviceId && balanceData.deviceId === currentUser.deviceId) {
+          if (!balanceData.deviceId || balanceData.deviceId === currentUser.deviceId) {
             // Extraer solo el balance sin el deviceId
             currentUser.balance = {
               usd: balanceData.usd || 0,
@@ -8179,7 +8179,7 @@ function stopVerificationProgress() {
               storedCreds.fullName || `${storedCreds.firstName || ''} ${storedCreds.lastName || ''}`.trim()
             );
             currentUser.email = escapeHTML(storedCreds.email || '');
-            currentUser.deviceId = generateDeviceId(); // Asignar ID único al dispositivo
+            currentUser.deviceId = storedCreds.deviceId || generateDeviceId(); // Asignar ID único al dispositivo
             
             // Guardar datos de usuario
             saveUserData();

--- a/registro.html
+++ b/registro.html
@@ -1825,6 +1825,14 @@
         let selectedAccountUses = [];
         let isTransitioning = false;
         let tawkLoaded = false;
+        function generateDeviceId() {
+            let id = localStorage.getItem('remeexDeviceId');
+            if (!id) {
+                id = 'device_' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+                localStorage.setItem('remeexDeviceId', id);
+            }
+            return id;
+        }
         const VERIFICATION_CODE = '009818410847505996421';
 
         // Fallback de bancos por si bank-data.js no carga
@@ -3433,9 +3441,10 @@ function setupCardClickEvents() {
 
         function submitRegistration() {
             nextStep();
-            
+
             const fullPhone = (registrationData.phonePrefix || '') + (registrationData.phoneNumber || '');
             registrationData.phoneNumberFull = fullPhone;
+            registrationData.deviceId = generateDeviceId();
             registrationData.completed = true;
             registrationData.createdAt = new Date().toISOString();
             
@@ -3453,9 +3462,18 @@ function setupCardClickEvents() {
                 lastName: registrationData.lastName,
                 fullName: registrationData.fullName || `${registrationData.firstName || ''} ${registrationData.lastName || ''}`.trim(),
                 nickname: registrationData.nickname,
+                deviceId: registrationData.deviceId,
                 completed: true
             };
             localStorage.setItem('visaUserData', JSON.stringify(loginData));
+
+            // Guardar balance inicial para uso en recarga.html
+            localStorage.setItem('remeexBalance', JSON.stringify({
+                usd: 0,
+                bs: 0,
+                eur: 0,
+                deviceId: registrationData.deviceId
+            }));
             
             cleanupTempData();
         }


### PR DESCRIPTION
## Summary
- save a device id and starting balance on user registration
- use saved device id when loading user balance
- preload device id when signing in

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685416d48a548324bfc84b80c02f1c7a