### PR TITLE
Fix support menu visibility on login page

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -1667,7 +1667,7 @@
       border-radius: var(--radius-md);
       box-shadow: var(--shadow-md);
       width: 220px;
-      z-index: 10;
+      z-index: 1001;
     }
 
     .support-menu.open {
@@ -8206,6 +8206,21 @@ function stopVerificationProgress() {
           }
         });
       }
+
+      // Cerrar el menú al hacer clic fuera o presionar ESC
+      document.addEventListener('click', function(e) {
+        if (menu && menu.classList.contains('open')) {
+          if (!menu.contains(e.target) && !supportBtn.contains(e.target)) {
+            menu.classList.remove('open');
+          }
+        }
+      });
+
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && menu && menu.classList.contains('open')) {
+          menu.classList.remove('open');
+        }
+      });
 
       function sendWhatsApp(msg) {
         const encoded = encodeURIComponent(msg);


### PR DESCRIPTION
## Summary
- improve z-index for login support menu so it displays on top
- close the support menu when the user clicks outside or presses Escape

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685441f89b8483249fc12e9c2c001725