### PR TITLE
Fix savings label visibility

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -392,6 +392,16 @@
       opacity: 0.7;
       margin-bottom: 1rem;
     }
+
+    /* Savings label inside balance card */
+    .balance-savings .btn-outline {
+      color: #fff;
+      border-color: rgba(255, 255, 255, 0.85);
+    }
+
+    .balance-savings .btn-outline:hover {
+      background: rgba(255, 255, 255, 0.2);
+    }
     
     .balance-actions {
       display: flex;


### PR DESCRIPTION
## Summary
- adjust savings button styling when displayed on the dark balance card

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854586331788324a65fa52cb4a9c963