### PR TITLE
Persist verification banner state

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -7783,7 +7783,8 @@ function stopVerificationProgress() {
             showVerificationProcessingBanner();
             updateVerificationProcessingBanner();
           } else {
-            hideVerificationProcessingBanner();
+            // Ocultar el banner sin eliminar el estado guardado
+            hideVerificationProcessingBanner(false);
           }
         } catch (e) {
           console.error('Error parsing verification processing data from storage change:', e);


### PR DESCRIPTION
## Summary
- prevent removal of verification status from localStorage when processing completes

## Testing
- `npm run build`
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6855bfd85e888324bde000f9d015ac81