### PR TITLE
UI tweaks on recarga page

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -136,12 +136,12 @@
     .header-actions {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.25rem;
     }
-    
+
     .header-action-btn {
-      width: 36px;
-      height: 36px;
+      width: 32px;
+      height: 32px;
       border-radius: var(--radius-full);
       display: flex;
       align-items: center;
@@ -581,8 +581,8 @@
     .transaction-item {
       display: flex;
       align-items: center;
-      gap: 0.75rem;
-      padding: 0.75rem;
+      gap: 0.5rem;
+      padding: 0.6rem;
       background: var(--neutral-100);
       border-radius: var(--radius-md);
       transition: all 0.3s ease;
@@ -596,8 +596,8 @@
     }
     
     .transaction-icon {
-      width: 36px;
-      height: 36px;
+      width: 32px;
+      height: 32px;
       border-radius: var(--radius-full);
       display: flex;
       align-items: center;
@@ -638,7 +638,7 @@
     
     .transaction-title {
       font-weight: 600;
-      font-size: 0.8rem;
+      font-size: 0.75rem;
       color: var(--neutral-900);
       margin-bottom: 0.125rem;
       white-space: nowrap;
@@ -685,8 +685,8 @@
       display: flex;
       align-items: center;
       flex-wrap: wrap;
-      gap: 0.5rem;
-      font-size: 0.7rem;
+      gap: 0.4rem;
+      font-size: 0.65rem;
       color: var(--neutral-600);
     }
     
@@ -864,15 +864,15 @@
     }
 
     .service-icon {
-      width: 48px;
-      height: 48px;
+      width: 40px;
+      height: 40px;
       border-radius: var(--radius-full);
       background: var(--primary);
       color: white;
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 1.25rem;
+      font-size: 1.1rem;
     }
 
     .service-icon.bills {
@@ -3485,13 +3485,13 @@
     }
 
     .contact-icon {
-      width: 48px;
-      height: 48px;
+      width: 40px;
+      height: 40px;
       border-radius: var(--radius-full);
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 1.25rem;
+      font-size: 1.1rem;
       flex-shrink: 0;
       color: white;
       margin-bottom: 0.25rem;
@@ -3838,7 +3838,7 @@
     .security-notice-close {
       cursor: pointer;
       color: var(--neutral-600);
-      font-size: 1rem;
+      font-size: 0.9rem;
     }
 
     /* Nuevo estilo para el contenedor de soporte después de 5 minutos */
@@ -4491,7 +4491,7 @@
     
     <div class="nav-item" data-section="support">
       <div class="nav-icon"><i class="fas fa-headset"></i></div>
-      <div class="nav-label">Soporte &amp; Ayuda</div>
+      <div class="nav-label">Ayuda</div>
     </div>
 
     <div class="nav-item" data-section="settings">
@@ -4770,7 +4770,7 @@
   <div class="support-overlay" id="support-overlay">
     <div class="support-container">
       <div class="support-header">
-        <div class="support-title">Soporte y Ayuda</div>
+        <div class="support-title">Ayuda</div>
         <div class="support-close" id="support-close"><i class="fas fa-times"></i></div>
       </div>
 


### PR DESCRIPTION
## Summary
- reduce service and contact icon sizes so all options fit on desktop
- rename bottom-nav and overlay sections to simply **Ayuda**
- ensure header actions visible on mobile by shrinking action buttons
- make transaction list more compact
- run `npm run build`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68565b4ed80083248ab471eaa962bd76