### PR TITLE
Ajustes de menús de servicios y ayuda

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -807,8 +807,8 @@
       border-top-right-radius: var(--radius-lg);
       padding: 1.5rem;
       animation: slideUp 0.4s ease;
-      max-height: 80vh;
-      overflow-y: auto;
+      max-height: none;
+      overflow-y: visible;
     }
 
     .service-header {
@@ -842,7 +842,7 @@
 
     .service-grid {
       display: grid;
-      grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: repeat(3, 1fr);
       gap: 1rem;
     }
 
@@ -1879,12 +1879,19 @@
 
     .support-option,
     .access-option {
-      display: block;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
       padding: 0.5rem 1rem;
       font-size: 0.8rem;
       color: var(--neutral-900);
       cursor: pointer;
       text-align: left;
+    }
+
+    .support-option i {
+      font-size: 0.9rem;
+      color: var(--primary);
     }
 
     .support-option:hover,
@@ -4086,7 +4093,7 @@
       }
 
       .service-grid {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(4, 1fr);
       }
     }
     
@@ -4236,9 +4243,18 @@
     <div class="support-container">
       <button class="btn btn-outline" id="support-btn"><i class="fas fa-headset"></i> Soporte</button>
       <div class="support-menu" id="support-menu">
-        <div class="support-option" id="recover-password">Recuperar contraseña</div>
-        <a href="https://wa.me/+17373018059" class="support-option whatsapp-link" id="whatsapp-support" target="_blank">Hablar por WhatsApp</a>
-        <div class="support-option" id="tawk-support">Chat en línea (Tawk.to)</div>
+        <div class="support-option" id="recover-password">
+          <i class="fas fa-key"></i>
+          <span>Recuperar contraseña</span>
+        </div>
+        <a href="https://wa.me/+17373018059" class="support-option whatsapp-link" id="whatsapp-support" target="_blank">
+          <i class="fab fa-whatsapp"></i>
+          <span>Hablar por WhatsApp</span>
+        </a>
+        <div class="support-option" id="tawk-support">
+          <i class="fas fa-comments"></i>
+          <span>Chat en línea (Tawk.to)</span>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- expand service menu so all opciones are visibles sin hacer scroll
- mostrar tres columnas de servicios por defecto
- mejorar menú de ayuda con íconos

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68565f0572e88324973b89d7c4c95bb6