### PR TITLE
Fix spacing for verification status cards

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -3048,7 +3048,7 @@
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .verification-status-item {
@@ -3061,6 +3061,7 @@
   color: var(--neutral-900);
   box-shadow: var(--shadow-sm);
   transition: all 0.3s ease;
+  margin-bottom: 0;
 }
 
 .verification-status-item:hover {


### PR DESCRIPTION
## Summary
- adjust spacing of verification status cards so they stack tightly

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68568afff0b08324874e1535c19bda4e