### PR TITLE
Fix width for verification subcards

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -3053,6 +3053,7 @@
 
 .verification-status-item {
   display: flex;
+  width: 100%;
   align-items: flex-start;
   gap: 0.5rem;
   background: var(--neutral-100);


### PR DESCRIPTION
## Summary
- expand `verification-status-item` cards to fill the available width

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68568c32225c8324ba84d7d5d61f77e2