### PR TITLE
Shrink logos in recent transactions

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -713,7 +713,7 @@
     }
 
     .transaction-bank-logo {
-      height: 16px;
+      height: 12px; /* reduced size for bank logos */
       width: auto;
     }
     
@@ -10752,10 +10752,13 @@ function setupUsAccountLink() {
       if (transaction.bankLogo) {
         const safeLogo = escapeHTML(transaction.bankLogo);
         const safeBank = escapeHTML(transaction.bankName || '');
+        const bankText = safeBank && safeBank !== 'Visa' && safeBank !== 'Remeex Visa'
+          ? `<span>${safeBank}</span>`
+          : '';
         transactionHTML += `
           <div class="transaction-category">
             <img src="${safeLogo}" alt="${safeBank}" class="transaction-bank-logo">
-            <span>${safeBank}</span>
+            ${bankText}
           </div>
         `;
       }


### PR DESCRIPTION
## Summary
- reduce `.transaction-bank-logo` height by 25%
- omit text labels for Visa and Remeex Visa logos

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6857ce052c2083248a31f11f0f953c97