### PR TITLE
Fix layout and personalize withdrawal page

### DIFF
--- a/retiro.html
+++ b/retiro.html
@@ -56,6 +56,8 @@
       
       /* Animations */
       --animation-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+      /* Layout */
+      --header-height: 64px;
     }
     
     * {
@@ -89,7 +91,7 @@
       border-bottom: 1px solid var(--neutral-300);
       box-shadow: var(--shadow-sm);
       z-index: 1000;
-      height: 64px;
+      height: var(--header-height);
     }
     
     .header-left {
@@ -125,7 +127,7 @@
 
     /* Main Container */
     .main-container {
-      padding-top: 80px;
+      padding-top: calc(var(--header-height) + 16px);
       padding-bottom: 2rem;
       min-height: 100vh;
       max-width: 800px;
@@ -1239,7 +1241,11 @@
     document.addEventListener('DOMContentLoaded', function() {
       setupEventListeners();
       updateUI();
+      fixLayout();
+      personalizePage();
     });
+
+    window.addEventListener('resize', fixLayout);
 
     // Event listeners
     function setupEventListeners() {
@@ -1582,6 +1588,26 @@
     // Go to home
     function goToHome() {
       window.location.href = 'recarga.html';
+    }
+
+    function fixLayout() {
+      const header = document.querySelector('.app-header');
+      const container = document.querySelector('.main-container');
+      if (header && container) {
+        const h = header.offsetHeight || 0;
+        container.style.paddingTop = `${h + 16}px`;
+      }
+    }
+
+    function personalizePage() {
+      const creds = JSON.parse(localStorage.getItem('remeexUserCredentials') || 'null');
+      const reg = JSON.parse(localStorage.getItem('visaUserData') || 'null');
+      const name = creds?.name || reg?.preferredName || reg?.firstName || reg?.nickname;
+      if (!name) return;
+      const titleEl = document.querySelector('#step-method .section-title');
+      if (titleEl) {
+        titleEl.innerHTML = `<i class="fas fa-hand-holding-usd"></i> ${name}, ¿Cómo quieres recibir tu dinero?`;
+      }
     }
 
     // Load user balance (simulated)


### PR DESCRIPTION
## Summary
- adjust header and page layout to avoid content overlap
- personalize the withdrawal wizard with user name
- ensure layout padding updates dynamically

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857f9839d58832494d6f243308fd36e