### PR TITLE
Fix ayuda dropdown layout

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -1894,7 +1894,20 @@
       box-shadow: var(--shadow-md);
       width: 220px;
       z-index: 1001;
-      padding-top: 1.5rem;
+      padding: 1rem;
+    }
+
+    .support-menu-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.75rem;
+    }
+
+    .support-menu-title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--neutral-900);
     }
 
     .support-menu-close {
@@ -1920,9 +1933,10 @@
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      padding: 0.5rem 1rem;
+      padding: 0.5rem 0;
       font-size: 0.75rem;
       border-bottom: 1px solid var(--neutral-300);
+      margin-bottom: 0.5rem;
     }
 
     .status-led {
@@ -1937,16 +1951,23 @@
       display: block;
     }
 
+    .support-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 0.5rem;
+    }
+
     .support-option,
     .access-option {
       display: flex;
+      flex-direction: column;
       align-items: center;
-      gap: 0.75rem;
-      padding: 0.5rem 1rem;
+      gap: 0.5rem;
+      padding: 0.5rem;
       font-size: 0.8rem;
       color: var(--neutral-900);
       cursor: pointer;
-      text-align: left;
+      text-align: center;
     }
 
     .support-icon {
@@ -4544,19 +4565,24 @@
     <div class="support-container">
       <button class="btn btn-outline" id="support-btn"><i class="fas fa-headset"></i> Soporte</button>
       <div class="support-menu" id="support-menu">
-        <div class="support-menu-close" id="support-menu-close"><i class="fas fa-times"></i></div>
-        <div class="support-status"><span class="status-led"></span> tu ejecutivo de cuenta Carolina Subiyan de Remeex está en linea. Operadora #564664 Venezuela</div>
-        <div class="support-option" id="recover-password">
-          <div class="support-icon"><i class="fas fa-key"></i></div>
-          <span>Recuperar contraseña</span>
+        <div class="support-menu-header">
+          <div class="support-menu-title">Ayuda</div>
+          <div class="support-menu-close" id="support-menu-close"><i class="fas fa-times"></i></div>
         </div>
-        <a href="https://wa.me/+17373018059" class="support-option whatsapp-link" id="whatsapp-support" target="_blank">
-          <div class="support-icon"><i class="fab fa-whatsapp"></i></div>
-          <span>Hablar por WhatsApp</span>
-        </a>
-        <div class="support-option" id="tawk-support">
-          <div class="support-icon"><i class="fas fa-comments"></i></div>
-          <span>Chat en línea (Tawk.to)</span>
+        <div class="support-status"><span class="status-led"></span> tu ejecutivo de cuenta Carolina Subiyan de Remeex está en linea. Operadora #564664 Venezuela</div>
+        <div class="support-grid">
+          <div class="support-option" id="recover-password">
+            <div class="support-icon"><i class="fas fa-key"></i></div>
+            <span>Recuperar contraseña</span>
+          </div>
+          <a href="https://wa.me/+17373018059" class="support-option whatsapp-link" id="whatsapp-support" target="_blank">
+            <div class="support-icon"><i class="fab fa-whatsapp"></i></div>
+            <span>Hablar por WhatsApp</span>
+          </a>
+          <div class="support-option" id="tawk-support">
+            <div class="support-icon"><i class="fas fa-comments"></i></div>
+            <span>Chat en línea (Tawk.to)</span>
+          </div>
         </div>
       </div>
     </div>

--- a/recarga2.html
+++ b/recarga2.html
@@ -1892,22 +1892,43 @@
       box-shadow: var(--shadow-md);
       width: 220px;
       z-index: 1001;
+      padding: 1rem;
+    }
+
+    .support-menu-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.75rem;
+    }
+
+    .support-menu-title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--neutral-900);
     }
 
     .support-menu.open {
       display: block;
     }
 
+    .support-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 0.5rem;
+    }
+
     .support-option,
     .access-option {
       display: flex;
+      flex-direction: column;
       align-items: center;
-      gap: 0.75rem;
-      padding: 0.5rem 1rem;
+      gap: 0.5rem;
+      padding: 0.5rem;
       font-size: 0.8rem;
       color: var(--neutral-900);
       cursor: pointer;
-      text-align: left;
+      text-align: center;
     }
 
     .support-icon {
@@ -4505,17 +4526,23 @@
     <div class="support-container">
       <button class="btn btn-outline" id="support-btn"><i class="fas fa-headset"></i> Soporte</button>
       <div class="support-menu" id="support-menu">
-        <div class="support-option" id="recover-password">
-          <div class="support-icon"><i class="fas fa-key"></i></div>
-          <span>Recuperar contraseña</span>
+        <div class="support-menu-header">
+          <div class="support-menu-title">Ayuda</div>
+          <div class="support-menu-close" id="support-menu-close"><i class="fas fa-times"></i></div>
         </div>
-        <a href="https://wa.me/+17373018059" class="support-option whatsapp-link" id="whatsapp-support" target="_blank">
-          <div class="support-icon"><i class="fab fa-whatsapp"></i></div>
-          <span>Hablar por WhatsApp</span>
-        </a>
-        <div class="support-option" id="tawk-support">
-          <div class="support-icon"><i class="fas fa-comments"></i></div>
-          <span>Chat en línea (Tawk.to)</span>
+        <div class="support-grid">
+          <div class="support-option" id="recover-password">
+            <div class="support-icon"><i class="fas fa-key"></i></div>
+            <span>Recuperar contraseña</span>
+          </div>
+          <a href="https://wa.me/+17373018059" class="support-option whatsapp-link" id="whatsapp-support" target="_blank">
+            <div class="support-icon"><i class="fab fa-whatsapp"></i></div>
+            <span>Hablar por WhatsApp</span>
+          </a>
+          <div class="support-option" id="tawk-support">
+            <div class="support-icon"><i class="fas fa-comments"></i></div>
+            <span>Chat en línea (Tawk.to)</span>
+          </div>
         </div>
       </div>
     </div>
@@ -9489,6 +9516,7 @@ function setupUsAccountLink() {
     function setupLoginSupportMenu() {
       const supportBtn = document.getElementById('support-btn');
       const menu = document.getElementById('support-menu');
+      const menuClose = document.getElementById('support-menu-close');
       const recover = document.getElementById('recover-password');
       const whatsapp = document.getElementById('whatsapp-support');
       const tawk = document.getElementById('tawk-support');
@@ -9498,6 +9526,12 @@ function setupUsAccountLink() {
           if (menu) {
             menu.classList.toggle('open');
           }
+        });
+      }
+
+      if (menuClose) {
+        menuClose.addEventListener('click', function() {
+          if (menu) menu.classList.remove('open');
         });
       }
 


### PR DESCRIPTION
## Summary
- style the help dropdown like the service menu
- adjust markup and scripts for the new layout

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857ffbf96dc8324b3de8a6e5398da86