### PR TITLE
Implement verification redirect flow

### DIFF
--- a/recarga.html
+++ b/recarga.html
@@ -6365,8 +6365,9 @@
       
       // Check for returning from transfer.html
       checkReturnFromTransfer();
-      
 
+      // Handle section redirects via query params
+      handleSectionRedirect();
 
       // NUEVA IMPLEMENTACIÓN: Verificar estado de procesamiento de verificación
       checkVerificationProcessingStatus();
@@ -6943,6 +6944,26 @@ function stopVerificationProgress() {
         }
       }
     }
+
+  // Manejar redirecciones iniciales a secciones específicas
+  function handleSectionRedirect() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('section') === 'mobile-payment') {
+      const dashboard = document.getElementById('dashboard-container');
+      const recharge = document.getElementById('recharge-container');
+      if (dashboard) dashboard.style.display = 'none';
+      if (recharge) recharge.style.display = 'block';
+
+      document.querySelectorAll('.payment-method-tab').forEach(t => t.classList.remove('active'));
+      const mobileTab = document.querySelector('.payment-method-tab[data-target="mobile-payment"]');
+      if (mobileTab) mobileTab.classList.add('active');
+      document.querySelectorAll('.payment-method-content').forEach(c => c.classList.remove('active'));
+      const mobileContent = document.getElementById('mobile-payment');
+      if (mobileContent) mobileContent.classList.add('active');
+
+      updateSavedCardUI();
+    }
+  }
 
     // Función para actualizar la tasa de cambio y recalcular todos los montos
     function updateExchangeRate(newRate) {

--- a/transferencia.html
+++ b/transferencia.html
@@ -5916,7 +5916,7 @@
       if (modal) {
         modal.style.display = 'flex';
       } else {
-        window.location.href = 'recarga.html';
+        window.location.href = 'recarga.html?section=mobile-payment';
       }
     }
 
@@ -6057,7 +6057,7 @@
       if (proceedBtn) {
         proceedBtn.addEventListener('click', function() {
           if (modal) modal.style.display = 'none';
-          window.location.href = 'recarga.html';
+          window.location.href = 'recarga.html?section=mobile-payment';
         });
       }
 


### PR DESCRIPTION
## Summary
- after withdrawal, send user to mobile payment section when selecting 'Validar ahora'
- update fallback URL in `showVerificationConfirmation`
- handle `section=mobile-payment` redirect on recarga page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68587389e82483248c2fe07a1b4535b2