### PR TITLE
Fix withdrawal receipt workflow

### DIFF
--- a/transferencia.html
+++ b/transferencia.html
@@ -6828,6 +6828,9 @@
         closeReceiptBtn.addEventListener('click', function() {
           const receiptModal = document.getElementById('receipt-modal');
           if (receiptModal) receiptModal.style.display = 'none';
+
+          // Mostrar instrucciones de verificación al continuar
+          showVerificationConfirmation();
         });
       }
       


### PR DESCRIPTION
## Summary
- show account verification modal after closing the withdrawal receipt

## Testing
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_685875d6c7e8832497071745b0e84acd