### PR TITLE
Use operator logos in registration

### DIFF
--- a/public/registro.html
+++ b/public/registro.html
@@ -488,6 +488,20 @@
             transform: scale(1.1);
         }
 
+        .option-card .logo {
+            width: 40px;
+            height: 40px;
+            margin-bottom: 10px;
+            object-fit: contain;
+            transition: all 0.3s ease;
+            flex-shrink: 0;
+        }
+
+        .option-card:hover .logo,
+        .option-card.selected .logo {
+            transform: scale(1.1);
+        }
+
         .option-card .label {
             font-size: 12px;
             font-weight: 600;
@@ -1503,21 +1517,15 @@
                     <label class="form-label">Operadora</label>
                     <div class="select-grid">
                         <div class="option-card" data-operator="movistar" data-prefix="0414">
-                            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"></path>
-                            </svg>
+                            <img class="logo" src="https://static.wikia.nocookie.net/logopedia/images/5/52/Movistar_2020.svg/revision/latest?cb=20200616003208&path-prefix=es" alt="Movistar logo" />
                             <span class="label">Movistar</span>
                         </div>
                         <div class="option-card" data-operator="digitel" data-prefix="0412">
-                            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"></path>
-                            </svg>
+                            <img class="logo" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Logo_DIGITEL.png/960px-Logo_DIGITEL.png" alt="Digitel logo" />
                             <span class="label">Digitel</span>
                         </div>
                         <div class="option-card" data-operator="movilnet" data-prefix="0416">
-                            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"></path>
-                            </svg>
+                            <img class="logo" src="http://www.movilnet.com.ve/sitio/imagesGenerales/logo.png" alt="Movilnet logo" />
                             <span class="label">Movilnet</span>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- show Movistar, Digitel and Movilnet logos when selecting phone operator
- style new logos for the operator cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685949aef3b48324a0bfaf81b235e0e7