### PR TITLE
Update audio playback for registration page

### DIFF
--- a/public/registro.html
+++ b/public/registro.html
@@ -1826,10 +1826,8 @@
     <!-- Contenedor para Tawk.to -->
     <div id="tawkto-container" class="tawkto-container"></div>
 
-    <!-- Música de bienvenida -->
-    <audio id="introMusic" preload="auto">
-        <source src="remeexvisa.ogg" type="audio/ogg">
-    </audio>
+    <!-- Contenedor para el audio de bienvenida -->
+    <div id="introMusicContainer" style="display:none;"></div>
     
     <script>
         // Variables globales
@@ -2282,12 +2280,13 @@ function setupCardClickEvents() {
             }
             if (!introMusicPlayed) {
                 introMusicPlayed = true;
-                const audio = document.getElementById('introMusic');
-                if (audio) {
-                    const playPromise = audio.play();
-                    if (playPromise !== undefined) {
-                        playPromise.catch(err => console.error('Audio playback failed:', err));
-                    }
+                const container = document.getElementById('introMusicContainer');
+                if (container) {
+                    const iframe = document.createElement('iframe');
+                    iframe.style.display = 'none';
+                    iframe.allow = 'autoplay';
+                    iframe.src = 'https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/remeex-visa/remeexvisa&auto_play=true';
+                    container.appendChild(iframe);
                 }
             }
             nextStep();


### PR DESCRIPTION
## Summary
- play SoundCloud track instead of bundled OGG
- hide the embedded player and autoplay once registration starts

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68597701d1748324b0649b28759b84ad