### PR TITLE
Fix login overlay spinner on recarga.html

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -2802,7 +2802,7 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      z-index: 1100;
+      z-index: 2100; /* Ensure overlay appears above login container */
       display: none;
     }
     


### PR DESCRIPTION
## Summary
- ensure the login loading overlay sits above the login form

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b04f32a948324b14b8906e3347f78