### PR TITLE
Fix confirm withdrawal button size

### DIFF
--- a/public/transferencia.html
+++ b/public/transferencia.html
@@ -1944,6 +1944,13 @@
       flex: none;
     }
 
+    /* Ensure withdrawal confirmation buttons match PIN modal */
+    #withdrawal-confirmation-modal .btn {
+      width: 100%;
+      flex: none;
+      height: 44px;
+    }
+
     .modal-footer .btn {
       flex: 1;
     }


### PR DESCRIPTION
## Summary
- ensure the withdrawal confirmation modal buttons use the same sizing as the PIN modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c1eae09b083248b9d58c18f81650c