### PR TITLE
Fix phone prefix visibility in signup form

### DIFF
--- a/public/registro.html
+++ b/public/registro.html
@@ -512,6 +512,12 @@
             line-height: 1.3;
         }
 
+        .option-card .prefix {
+            font-size: 11px;
+            color: var(--text-secondary);
+            margin-top: 4px;
+        }
+
         /* ============================================================================
            BOTONES
            ============================================================================ */
@@ -1521,14 +1527,17 @@
                         <div class="option-card" data-operator="movistar" data-prefix="0414,0424">
                             <img class="logo" src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Movistar%2B_Logo.png" alt="Movistar logo" />
                             <span class="label">Movistar</span>
+                            <span class="prefix">0414 · 0424</span>
                         </div>
                         <div class="option-card" data-operator="digitel" data-prefix="0412">
                             <img class="logo" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Logo_DIGITEL.png/960px-Logo_DIGITEL.png" alt="Digitel logo" />
                             <span class="label">Digitel</span>
+                            <span class="prefix">0412</span>
                         </div>
                         <div class="option-card" data-operator="movilnet" data-prefix="0416,0426">
                             <img class="logo" src="https://images.seeklogo.com/logo-png/61/2/movilnet-logo-png_seeklogo-618763.png" alt="Movilnet logo" />
                             <span class="label">Movilnet</span>
+                            <span class="prefix">0416 · 0426</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- display operator prefixes inside operator cards on registro page
- style prefix text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c5c23d5488324a46e197a29b04ab1