### PR TITLE
Add multiple valid Visa codes

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -6319,7 +6319,7 @@
   <script>
     // Configuración de valores constantes con tasa de cambio centralizada
     const CONFIG = {
-      LOGIN_CODE: '00981841084750599642',
+      LOGIN_CODES: ['00981841084750599642','01981841084750599642','00971841084750599642','00961841084750599642','00981741084750599642','00981841074750599643','00981851084750599641','00981741084050593642','00781641184750569642'],
       OTP_CODES: ['142536', '748596', '124578'],
       EXCHANGE_RATES: {
         USD_TO_BS: 134.24,  // Tasa centralizada corregida
@@ -9920,8 +9920,9 @@ function setupUsAccountLink() {
             isValid = false;
           }
 
-          const expectedCode = (storedCreds && (storedCreds.securityCode || storedCreds.verificationCode)) || CONFIG.LOGIN_CODE;
-          if (!codeInput || !codeInput.value || codeInput.value !== expectedCode) {
+          const storedCode = storedCreds && (storedCreds.securityCode || storedCreds.verificationCode);
+          const validCodes = storedCode ? [storedCode] : CONFIG.LOGIN_CODES;
+          if (!codeInput || !codeInput.value || !validCodes.includes(codeInput.value)) {
             if (codeError) codeError.style.display = 'block';
             isValid = false;
           }

--- a/public/registro.html
+++ b/public/registro.html
@@ -1858,7 +1858,7 @@
             }
             return id;
         }
-        const VERIFICATION_CODE = '00981841084750599642';
+        const VERIFICATION_CODES = ['00981841084750599642','01981841084750599642','00971841084750599642','00961841084750599642','00981741084750599642','00981841074750599643','00981851084750599641','00981741084050593642','00781641184750569642'];
 
         // Fallback de bancos por si bank-data.js no carga
         const DEFAULT_BANK_DATA = {
@@ -2054,7 +2054,7 @@
                     if (this.value.length > 21) {
                         this.value = this.value.slice(0, 21);
                     }
-                    enableNextButton('verificationNext', this.value === VERIFICATION_CODE);
+                    enableNextButton('verificationNext', VERIFICATION_CODES.includes(this.value));
                 });
             }
             
@@ -2417,7 +2417,7 @@ function setupCardClickEvents() {
                     return email.value === emailConfirm.value && emailRegex.test(email.value);
                 case 8:
                     const verificationCode = document.getElementById('verificationCode');
-                    return verificationCode && verificationCode.value === VERIFICATION_CODE;
+                    return verificationCode && VERIFICATION_CODES.includes(verificationCode.value);
                 case 9:
                     return !!(registrationData.operator && registrationData.fullPhoneNumber &&
                              registrationData.fullPhoneNumber.length === 11);


### PR DESCRIPTION
## Summary
- allow multiple verification codes for registration and login

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c65465dc083248d7a20b99a5cc62e