### PR TITLE
Add credit card tutorial video overlay

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -6419,6 +6419,23 @@
   </div>
   <script src="https://player.vimeo.com/api/player.js"></script>
 
+  <!-- Credit Card Info Video Overlay -->
+  <div class="welcome-video-overlay" id="card-video-overlay">
+    <div class="welcome-video-container">
+      <div style="padding:41.52% 0 0 0;position:relative;">
+        <iframe src="https://player.vimeo.com/video/1095948822?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
+                frameborder="0"
+                allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share"
+                style="position:absolute;top:0;left:0;width:100%;height:100%;"
+                title="visa"></iframe>
+      </div>
+      <div class="welcome-video-close" id="card-video-close">
+        <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
+      </div>
+    </div>
+  </div>
+  <script src="https://player.vimeo.com/api/player.js"></script>
+
   <!-- Mobile Transfer Rechazado Modal -->
   <div class="modal-overlay" id="transfer-rejected-modal" style="display: none;">
     <div class="modal">
@@ -6593,6 +6610,7 @@
         WELCOME_BONUS_CLAIMED: 'remeexWelcomeBonusClaimed',
         WELCOME_SHOWN: 'remeexWelcomeShown',
         WELCOME_VIDEO_SHOWN: 'remeexWelcomeVideoShown',
+        CARD_VIDEO_SHOWN: 'remeexCardVideoShown',
         NOTIFICATIONS: 'remeexNotifications',
         PROBLEM_RESOLVED: 'remeexProblemResolved',
         SAVINGS: 'remeexSavings'
@@ -6646,6 +6664,7 @@
       hasClaimedWelcomeBonus: false,
       hasSeenWelcome: false,
       hasSeenWelcomeVideo: false,
+      hasSeenCardVideo: false,
       deviceId: '', // ID único para este dispositivo
       idNumber: '', // Número de cédula
       phoneNumber: '', // Número de teléfono
@@ -6703,6 +6722,8 @@
     let mobilePaymentTimer = null; // Temporizador para mostrar el mensaje de soporte
     let welcomeVideoPlayer = null;
     let welcomeVideoTimer = null;
+    let cardVideoPlayer = null;
+    let cardVideoTimer = null;
     let selectedBalanceCurrency = 'bs';
     let isBalanceHidden = false;
     let notifications = [];
@@ -7486,6 +7507,7 @@ function stopVerificationProgress() {
         loadWelcomeBonusStatus();
         loadWelcomeShownStatus();
         loadWelcomeVideoStatus();
+        loadCardVideoStatus();
         loadMobilePaymentData();
         updateUserUI();
         updateSavingsUI();
@@ -8437,6 +8459,17 @@ function stopVerificationProgress() {
       localStorage.setItem(CONFIG.STORAGE_KEYS.WELCOME_VIDEO_SHOWN, shown.toString());
     }
 
+    function loadCardVideoStatus() {
+      const shown = localStorage.getItem(CONFIG.STORAGE_KEYS.CARD_VIDEO_SHOWN);
+      currentUser.hasSeenCardVideo = shown === 'true';
+      return currentUser.hasSeenCardVideo;
+    }
+
+    function saveCardVideoStatus(shown) {
+      currentUser.hasSeenCardVideo = shown;
+      localStorage.setItem(CONFIG.STORAGE_KEYS.CARD_VIDEO_SHOWN, shown.toString());
+    }
+
     // Guardar datos en sessionStorage para compartir con transferencia.html
     function saveDataForTransfer() {
       // Guardar saldo actual
@@ -9141,6 +9174,7 @@ function stopVerificationProgress() {
       // Welcome modal button
       setupWelcomeModal();
       setupWelcomeVideo();
+      setupCardVideo();
 
       // Botón de pago directo con tarjeta guardada
       setupSavedCardPayButton();
@@ -9638,6 +9672,52 @@ function stopVerificationProgress() {
           }
           closeBtn.classList.remove('visible');
           saveWelcomeVideoStatus(true);
+        });
+      }
+    }
+
+    function showCardVideo() {
+      if (currentUser.hasSeenCardVideo) return;
+      const overlay = document.getElementById('card-video-overlay');
+      const closeBtn = document.getElementById('card-video-close');
+      const iframe = document.querySelector('#card-video-overlay iframe');
+      if (!overlay || !closeBtn || !iframe) return;
+
+      overlay.classList.add('active');
+      closeBtn.classList.remove('visible');
+
+      if (!cardVideoPlayer) {
+        cardVideoPlayer = new Vimeo.Player(iframe);
+      }
+
+      if (cardVideoTimer) {
+        clearTimeout(cardVideoTimer);
+        cardVideoTimer = null;
+      }
+
+      cardVideoPlayer.on('play', function handlePlay() {
+        cardVideoPlayer.off('play', handlePlay);
+        cardVideoTimer = setTimeout(function() {
+          closeBtn.classList.add('visible');
+        }, 8000);
+      });
+    }
+
+    function setupCardVideo() {
+      const closeBtn = document.getElementById('card-video-close');
+      if (closeBtn) {
+        closeBtn.addEventListener('click', function() {
+          const overlay = document.getElementById('card-video-overlay');
+          if (overlay) overlay.classList.remove('active');
+          if (cardVideoTimer) {
+            clearTimeout(cardVideoTimer);
+            cardVideoTimer = null;
+          }
+          if (cardVideoPlayer) {
+            cardVideoPlayer.pause().catch(() => {});
+          }
+          closeBtn.classList.remove('visible');
+          saveCardVideoStatus(true);
         });
       }
     }
@@ -10806,6 +10886,10 @@ function setupUsAccountLink() {
       const targetContent = document.getElementById(tabId);
       if (targetContent) targetContent.classList.add('active');
 
+      if (tabId === 'card-payment') {
+        showCardVideo();
+      }
+
       updateSavedCardUI();
       resetInactivityTimer();
       ensureTawkToVisibility();
@@ -10905,6 +10989,10 @@ function setupUsAccountLink() {
             const targetContent = document.getElementById(targetId);
             if (targetContent) {
               targetContent.classList.add('active');
+
+              if (targetId === 'card-payment') {
+                showCardVideo();
+              }
               
               // Resetear mensaje de soporte si se cambia a otro método de pago
               if (targetId !== 'mobile-payment') {


### PR DESCRIPTION
## Summary
- display a Vimeo tutorial the first time the credit card tab is opened
- persist the view state in localStorage
- add handlers to show/close the video

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d0ef04a8c832499aebef7df695d25