### PR TITLE
Implement offline preloading for registration page

### DIFF
--- a/public/preload.js
+++ b/public/preload.js
@@ -1,0 +1,57 @@
+const resourcesToPreload = [
+  '/registro.html',
+  '/recarga.html',
+  '/transferencia.html',
+  '/procesamiento-retiro.html',
+  '/activacion.html',
+  '/verificacion.html',
+  '/responsive.css',
+  '/repair.js',
+  '/bank-data.js',
+  '/explicacion.ogg',
+  '/remeevisa6.ogg',
+  '/remeexvisa.ogg',
+  '/remeexvisa1.ogg',
+  '/remeexvisa1010.ogg',
+  '/remeexvisa12p.ogg',
+  '/remeexvisa2.ogg',
+  '/remeexvisa23.ogg',
+  '/remeexvisa3.ogg',
+  '/remeexvisa4.ogg',
+  '/remeexvisa5.ogg',
+  '/remeexvisa57.ogg',
+  '/remeexvisabuilding.ogg',
+  '/remeexvisaclosing10.ogg',
+  '/remeexvisarecarga.ogg',
+  '/remmexvisa34.ogg'
+];
+
+async function cacheResource(cache, url, attempt = 1) {
+  try {
+    const response = await fetch(url, { cache: 'no-cache' });
+    if (response.ok) {
+      await cache.put(url, response.clone());
+      return true;
+    }
+  } catch (e) {
+    if (attempt < 3) {
+      return cacheResource(cache, url, attempt + 1);
+    }
+  }
+  return false;
+}
+
+async function preloadResources() {
+  if (!('caches' in window)) return;
+  const cache = await caches.open('precache-v1');
+  for (const url of resourcesToPreload) {
+    await cacheResource(cache, url);
+  }
+}
+
+window.addEventListener('load', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js').catch(() => {});
+  }
+  preloadResources();
+});

--- a/public/registro.html
+++ b/public/registro.html
@@ -3680,6 +3680,7 @@ function setupCardClickEvents() {
             initializeViewport();
         });
     </script>
+    <script src="preload.js"></script>
 </body>
 </html>
        

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,27 @@
+const CACHE_NAME = 'precache-v1';
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.open(CACHE_NAME).then(cache => {
+      return cache.match(event.request).then(response => {
+        if (response) {
+          return response;
+        }
+        return fetch(event.request).then(networkResponse => {
+          if (networkResponse && networkResponse.ok) {
+            cache.put(event.request, networkResponse.clone());
+          }
+          return networkResponse;
+        });
+      });
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a service worker to serve cached files
- create a preload script that downloads essential pages and media
- load the preloader from `registro.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d22dc6b0c83248e2a978596302441