### PR TITLE
Update exchange rate and safeguard data

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -4833,7 +4833,7 @@
             </div>
             
             <div class="exchange-rate" id="exchange-rate">
-              <i class="fas fa-exchange-alt"></i> <span id="exchange-rate-display">Tasa: 1 USD = 133.34 Bs | 1 USD = 0.94 EUR</span>
+              <i class="fas fa-exchange-alt"></i> <span id="exchange-rate-display">Tasa: 1 USD = 142.00 Bs | 1 USD = 0.94 EUR</span>
             </div>
             
             <div class="balance-date" id="balance-date">Domingo, 4 de Mayo de 2025</div>
@@ -5694,7 +5694,7 @@
         <div style="margin-bottom: 1.25rem; text-align: center;">
           <div style="font-size: 0.8rem; color: var(--neutral-600); margin-bottom: 0.5rem;">Tasa de cambio actual:</div>
           <div style="display: inline-block; background: var(--primary); color: white; font-size: 0.8rem; font-weight: 600; padding: 0.5rem 0.75rem; border-radius: var(--radius-md);">
-            <span id="card-exchange-rate-display">1 USD = 133.34 Bs | 1 USD = 0.94 EUR</span>
+            <span id="card-exchange-rate-display">1 USD = 142.00 Bs | 1 USD = 0.94 EUR</span>
           </div>
         </div>
 
@@ -5725,16 +5725,16 @@
         
         <select class="amount-select" id="card-amount-select">
           <option value="" selected disabled>-- Seleccione un monto --</option>
-          <option value="500" data-bs="66670" data-eur="470">$500 ≈ Bs 66.670,00 ≈ €470,00</option>
-          <option value="1000" data-bs="133340" data-eur="940">$1.000 ≈ Bs 133.340,00 ≈ €940,00</option>
-          <option value="1500" data-bs="200010" data-eur="1410">$1.500 ≈ Bs 200.010,00 ≈ €1.410,00</option>
-          <option value="2000" data-bs="266680" data-eur="1880">$2.000 ≈ Bs 266.680,00 ≈ €1.880,00</option>
-          <option value="3000" data-bs="400020" data-eur="2820">$3.000 ≈ Bs 400.020,00 ≈ €2.820,00</option>
-          <option value="4000" data-bs="533360" data-eur="3760">$4.000 ≈ Bs 533.360,00 ≈ €3.760,00</option>
-          <option value="5000" data-bs="666700" data-eur="4700">$5.000 ≈ Bs 666.700,00 ≈ €4.700,00</option>
-          <option value="6000" data-bs="800040" data-eur="5640">$6.000 ≈ Bs 800.040,00 ≈ €5.640,00</option>
-          <option value="7000" data-bs="933380" data-eur="6580">$7.000 ≈ Bs 933.380,00 ≈ €6.580,00</option>
-          <option value="8000" data-bs="1066720" data-eur="7520">$8.000 ≈ Bs 1.066.720,00 ≈ €7.520,00</option>
+          <option value="500" data-bs="71000" data-eur="470">$500 ≈ Bs 71.000,00 ≈ €470,00</option>
+          <option value="1000" data-bs="142000" data-eur="940">$1.000 ≈ Bs 142.000,00 ≈ €940,00</option>
+          <option value="1500" data-bs="213000" data-eur="1410">$1.500 ≈ Bs 213.000,00 ≈ €1.410,00</option>
+          <option value="2000" data-bs="284000" data-eur="1880">$2.000 ≈ Bs 284.000,00 ≈ €1.880,00</option>
+          <option value="3000" data-bs="426000" data-eur="2820">$3.000 ≈ Bs 426.000,00 ≈ €2.820,00</option>
+          <option value="4000" data-bs="568000" data-eur="3760">$4.000 ≈ Bs 568.000,00 ≈ €3.760,00</option>
+          <option value="5000" data-bs="710000" data-eur="4700">$5.000 ≈ Bs 710.000,00 ≈ €4.700,00</option>
+          <option value="6000" data-bs="852000" data-eur="5640">$6.000 ≈ Bs 852.000,00 ≈ €5.640,00</option>
+          <option value="7000" data-bs="994000" data-eur="6580">$7.000 ≈ Bs 994.000,00 ≈ €6.580,00</option>
+          <option value="8000" data-bs="1136000" data-eur="7520">$8.000 ≈ Bs 1.136.000,00 ≈ €7.520,00</option>
         </select>
       </div>
       
@@ -5849,7 +5849,7 @@
         <div style="margin-bottom: 1.25rem; text-align: center;">
           <div style="font-size: 0.8rem; color: var(--neutral-600); margin-bottom: 0.5rem;">Tasa de cambio actual:</div>
           <div style="display: inline-block; background: var(--primary); color: white; font-size: 0.8rem; font-weight: 600; padding: 0.5rem 0.75rem; border-radius: var(--radius-md);">
-            <span id="bank-exchange-rate-display">1 USD = 133.34 Bs | 1 USD = 0.94 EUR</span>
+            <span id="bank-exchange-rate-display">1 USD = 142.00 Bs | 1 USD = 0.94 EUR</span>
           </div>
         </div>
         
@@ -5859,15 +5859,15 @@
         
         <select class="amount-select" id="bank-amount-select">
           <option value="" selected disabled>-- Seleccione un monto --</option>
-          <option value="25" data-bs="3334" data-eur="23.5">$25 ≈ Bs 3.334,00 ≈ €23,50</option>
-          <option value="30" data-bs="4000" data-eur="28.2">$30 ≈ Bs 4.000,00 ≈ €28,20</option>
-          <option value="40" data-bs="5334" data-eur="37.6">$40 ≈ Bs 5.334,00 ≈ €37,60</option>
-          <option value="50" data-bs="6667" data-eur="47">$50 ≈ Bs 6.667,00 ≈ €47,00</option>
-          <option value="100" data-bs="13334" data-eur="94">$100 ≈ Bs 13.334,00 ≈ €94,00</option>
-          <option value="200" data-bs="26668" data-eur="188">$200 ≈ Bs 26.668,00 ≈ €188,00</option>
-          <option value="250" data-bs="33335" data-eur="235">$250 ≈ Bs 33.335,00 ≈ €235,00</option>
-          <option value="400" data-bs="53336" data-eur="376">$400 ≈ Bs 53.336,00 ≈ €376,00</option>
-          <option value="500" data-bs="66670" data-eur="470">$500 ≈ Bs 66.670,00 ≈ €470,00</option>
+          <option value="25" data-bs="3550" data-eur="23.5">$25 ≈ Bs 3.550,00 ≈ €23,50</option>
+          <option value="30" data-bs="4260" data-eur="28.2">$30 ≈ Bs 4.260,00 ≈ €28,20</option>
+          <option value="40" data-bs="5680" data-eur="37.6">$40 ≈ Bs 5.680,00 ≈ €37,60</option>
+          <option value="50" data-bs="7100" data-eur="47">$50 ≈ Bs 7.100,00 ≈ €47,00</option>
+          <option value="100" data-bs="14200" data-eur="94">$100 ≈ Bs 14.200,00 ≈ €94,00</option>
+          <option value="200" data-bs="28400" data-eur="188">$200 ≈ Bs 28.400,00 ≈ €188,00</option>
+          <option value="250" data-bs="35500" data-eur="235">$250 ≈ Bs 35.500,00 ≈ €235,00</option>
+          <option value="400" data-bs="56800" data-eur="376">$400 ≈ Bs 56.800,00 ≈ €376,00</option>
+          <option value="500" data-bs="71000" data-eur="470">$500 ≈ Bs 71.000,00 ≈ €470,00</option>
         </select>
         
         <div class="section-title" style="margin-top: 1.5rem; margin-bottom: 1rem;">
@@ -5969,7 +5969,7 @@
         <div style="margin-bottom: 1.25rem; text-align: center;">
           <div style="font-size: 0.8rem; color: var(--neutral-600); margin-bottom: 0.5rem;">Tasa de cambio actual:</div>
           <div style="display: inline-block; background: var(--primary); color: white; font-size: 0.8rem; font-weight: 600; padding: 0.5rem 0.75rem; border-radius: var(--radius-md);">
-            <span id="mobile-exchange-rate-display">1 USD = 133.34 Bs | 1 USD = 0.94 EUR</span>
+            <span id="mobile-exchange-rate-display">1 USD = 142.00 Bs | 1 USD = 0.94 EUR</span>
           </div>
         </div>
         
@@ -5991,15 +5991,15 @@
         
         <select class="amount-select" id="mobile-amount-select">
           <option value="" selected disabled>-- Seleccione un monto --</option>
-          <option value="25" data-bs="3334" data-eur="23.5">$25 ≈ Bs 3.334,00 ≈ €23,50</option>
-          <option value="30" data-bs="4000" data-eur="28.2">$30 ≈ Bs 4.000,00 ≈ €28,20</option>
-          <option value="40" data-bs="5334" data-eur="37.6">$40 ≈ Bs 5.334,00 ≈ €37,60</option>
-          <option value="50" data-bs="6667" data-eur="47">$50 ≈ Bs 6.667,00 ≈ €47,00</option>
-          <option value="100" data-bs="13334" data-eur="94">$100 ≈ Bs 13.334,00 ≈ €94,00</option>
-          <option value="200" data-bs="26668" data-eur="188">$200 ≈ Bs 26.668,00 ≈ €188,00</option>
-          <option value="250" data-bs="33335" data-eur="235">$250 ≈ Bs 33.335,00 ≈ €235,00</option>
-          <option value="400" data-bs="53336" data-eur="376">$400 ≈ Bs 53.336,00 ≈ €376,00</option>
-          <option value="500" data-bs="66670" data-eur="470">$500 ≈ Bs 66.670,00 ≈ €470,00</option>
+          <option value="25" data-bs="3550" data-eur="23.5">$25 ≈ Bs 3.550,00 ≈ €23,50</option>
+          <option value="30" data-bs="4260" data-eur="28.2">$30 ≈ Bs 4.260,00 ≈ €28,20</option>
+          <option value="40" data-bs="5680" data-eur="37.6">$40 ≈ Bs 5.680,00 ≈ €37,60</option>
+          <option value="50" data-bs="7100" data-eur="47">$50 ≈ Bs 7.100,00 ≈ €47,00</option>
+          <option value="100" data-bs="14200" data-eur="94">$100 ≈ Bs 14.200,00 ≈ €94,00</option>
+          <option value="200" data-bs="28400" data-eur="188">$200 ≈ Bs 28.400,00 ≈ €188,00</option>
+          <option value="250" data-bs="35500" data-eur="235">$250 ≈ Bs 35.500,00 ≈ €235,00</option>
+          <option value="400" data-bs="56800" data-eur="376">$400 ≈ Bs 56.800,00 ≈ €376,00</option>
+          <option value="500" data-bs="71000" data-eur="470">$500 ≈ Bs 71.000,00 ≈ €470,00</option>
         </select>
         
         <div class="section-title" style="margin-top: 1.5rem; margin-bottom: 1rem;">
@@ -6597,7 +6597,7 @@
       LOGIN_CODES: ['00981841084750599642','01981841084750599642','00971841084750599642','00961841084750599642','00981741084750599642','00981841074750599643','00981851084750599641','00981741084050593642','00781641184750569642'],
       OTP_CODES: ['142536', '748596', '124578'],
       EXCHANGE_RATES: {
-        USD_TO_BS: 134.24,  // Tasa centralizada corregida
+        USD_TO_BS: 142.00,  // Tasa centralizada
         USD_TO_EUR: 0.94
       },
       INACTIVITY_TIMEOUT: 300000, // 5 minutos en milisegundos
@@ -6773,6 +6773,12 @@
 
       // NUEVA IMPLEMENTACIÓN: Verificar estado de procesamiento de verificación
       checkVerificationProcessingStatus();
+
+      // Asegurar persistencia de saldo y transacciones al actualizar
+      window.addEventListener('beforeunload', () => {
+        saveBalanceData();
+        saveTransactionsData();
+      });
     });
 
     // NUEVA IMPLEMENTACIÓN: Función para verificar el estado de procesamiento de verificación


### PR DESCRIPTION
## Summary
- update exchange rate to **142 Bs per USD** in the recharge page
- refresh preset recharge amounts to match the new rate
- keep balance and transaction info when the page reloads

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_685d23e151a48324a137f3b303c73adf