### PR TITLE
Add dark and silver theme toggles

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -4671,6 +4671,33 @@
       transform: translateX(-50%) scale(1.05);
       box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
     }
+
+    /* Theme styles */
+    body.dark-mode {
+      --neutral-100: #1a1f37;
+      --neutral-200: #293249;
+      --neutral-300: #4f5d75;
+      --neutral-900: #ffffff;
+      background: #121212;
+      color: var(--neutral-100);
+    }
+
+    body.silver-mode {
+      --neutral-100: rgba(255, 255, 255, 0.8);
+      --neutral-200: rgba(255, 255, 255, 0.6);
+      --neutral-300: rgba(255, 255, 255, 0.4);
+      --neutral-900: #1a1f37;
+      backdrop-filter: blur(10px);
+      background: linear-gradient(135deg, rgba(255,255,255,0.9), rgba(230,240,255,0.8));
+    }
+
+    body.silver-mode .card,
+    body.silver-mode .settings-container,
+    body.silver-mode .bottom-nav,
+    body.silver-mode .app-header {
+      background: rgba(255, 255, 255, 0.5);
+      backdrop-filter: blur(10px);
+    }
   </style>
   <link rel="stylesheet" href="responsive.css">
 </head>
@@ -5645,6 +5672,20 @@
                 <option value="bs">Bs</option>
                 <option value="eur">EUR</option>
               </select>
+            </div>
+            <div class="toggle-row">
+              <span>Modo Oscuro</span>
+              <label class="switch">
+                <input type="checkbox" id="dark-mode-toggle">
+                <span class="slider round"></span>
+              </label>
+            </div>
+            <div class="toggle-row">
+              <span>Modo Silver</span>
+              <label class="switch">
+                <input type="checkbox" id="silver-mode-toggle">
+                <span class="slider round"></span>
+              </label>
             </div>
           </div>
         </details>
@@ -6785,7 +6826,8 @@
     let notifications = [];
 
     // DOM Ready
-    document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function() {
+      applySavedTheme();
       // Iniciar aplicación
       initApp();
 
@@ -9282,6 +9324,9 @@ function stopVerificationProgress() {
       // Bono de bienvenida
       setupWelcomeBonus();
 
+      // Tema
+      setupThemeToggles();
+
       // Filtro de transacciones
       setupTransactionFilter();
 
@@ -11562,7 +11607,7 @@ function setupUsAccountLink() {
       }
     }
 
-    function setupBankManagement() {
+  function setupBankManagement() {
       const addBtn = document.getElementById('add-bank-btn');
       if (!addBtn) return;
       addBtn.addEventListener('click', function() {
@@ -11575,6 +11620,42 @@ function setupUsAccountLink() {
           populateAccountCard();
         }
       });
+    }
+
+    function applySavedTheme() {
+      const theme = localStorage.getItem('remeexTheme');
+      document.body.classList.toggle('dark-mode', theme === 'dark');
+      document.body.classList.toggle('silver-mode', theme === 'silver');
+    }
+
+    function setupThemeToggles() {
+      const darkToggle = document.getElementById('dark-mode-toggle');
+      const silverToggle = document.getElementById('silver-mode-toggle');
+      const theme = localStorage.getItem('remeexTheme');
+      if (darkToggle) {
+        darkToggle.checked = theme === 'dark';
+        darkToggle.addEventListener('change', () => {
+          if (darkToggle.checked) {
+            localStorage.setItem('remeexTheme', 'dark');
+            if (silverToggle) silverToggle.checked = false;
+          } else {
+            localStorage.setItem('remeexTheme', 'default');
+          }
+          applySavedTheme();
+        });
+      }
+      if (silverToggle) {
+        silverToggle.checked = theme === 'silver';
+        silverToggle.addEventListener('change', () => {
+          if (silverToggle.checked) {
+            localStorage.setItem('remeexTheme', 'silver');
+            if (darkToggle) darkToggle.checked = false;
+          } else {
+            localStorage.setItem('remeexTheme', 'default');
+          }
+          applySavedTheme();
+        });
+      }
     }
 
     function displayPreLoginBalance() {

--- a/public/transferencia.html
+++ b/public/transferencia.html
@@ -3533,6 +3533,32 @@
       background: rgba(26, 31, 113, 0.05);
       transform: translateY(-3px);
     }
+
+    /* Theme styles */
+    body.dark-mode {
+      --neutral-100: #1a1f37;
+      --neutral-200: #293249;
+      --neutral-300: #4f5d75;
+      --neutral-900: #ffffff;
+      background: #121212;
+      color: var(--neutral-100);
+    }
+
+    body.silver-mode {
+      --neutral-100: rgba(255, 255, 255, 0.8);
+      --neutral-200: rgba(255, 255, 255, 0.6);
+      --neutral-300: rgba(255, 255, 255, 0.4);
+      --neutral-900: #1a1f37;
+      backdrop-filter: blur(10px);
+      background: linear-gradient(135deg, rgba(255,255,255,0.9), rgba(230,240,255,0.8));
+    }
+
+    body.silver-mode .card,
+    body.silver-mode .bottom-nav,
+    body.silver-mode .app-header {
+      background: rgba(255, 255, 255, 0.5);
+      backdrop-filter: blur(10px);
+    }
   </style>
 </head>
 
@@ -4669,8 +4695,14 @@
     let verificationInProgress = false;
     let transactionHistory = [];
     let pendingTransactions = [];
-    let currentCurrency = 'bs'; // Para toggle de moneda
-    let selectedCurrency = 'bs'; // Para input de monto
+let currentCurrency = 'bs'; // Para toggle de moneda
+let selectedCurrency = 'bs'; // Para input de monto
+
+    function applySavedTheme() {
+      const theme = localStorage.getItem('remeexTheme');
+      document.body.classList.toggle('dark-mode', theme === 'dark');
+      document.body.classList.toggle('silver-mode', theme === 'silver');
+    }
 
     // DOM Ready
     document.addEventListener('DOMContentLoaded', function() {
@@ -4678,6 +4710,7 @@
         history.scrollRestoration = 'manual';
       }
       window.scrollTo(0, 0);
+      applySavedTheme();
       initApp();
       setupEventListeners();
       loadUserDataFromSession();


### PR DESCRIPTION
## Summary
- add dark/silver theme styles
- add theme toggles in account settings
- apply theme on page load for both recarga and transferencia

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f05ec6c83249a6985ec47685df1