### PR TITLE
Restrict direct access to transferencia

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -11153,6 +11153,9 @@ function setupUsAccountLink() {
             // Guardar información necesaria en sessionStorage para compartir con transferencia.html
             saveDataForTransfer();
 
+            // Marcar que la navegación proviene de recarga.html
+            sessionStorage.setItem('fromRecarga', 'true');
+
             // Redirigir a la página de transferencia
             window.location.href = 'transferencia.html';
 

--- a/public/transferencia.html
+++ b/public/transferencia.html
@@ -2,6 +2,17 @@
 <html lang="es">
 <head>
   <script src="repair.js"></script>
+  <script>
+    (function() {
+      const ref = document.referrer ? document.referrer.split('/').pop() : '';
+      const fromRecarga = sessionStorage.getItem('fromRecarga') === 'true';
+      if (ref !== 'recarga.html' && !fromRecarga) {
+        window.location.replace('recarga.html');
+      } else {
+        sessionStorage.removeItem('fromRecarga');
+      }
+    })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>REMEEX - Retiro de Fondos</title>


### PR DESCRIPTION
## Summary
- set flag when navigating from recarga.html
- block viewing transferencia.html unless coming from recarga.html

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685db052d4688324bb59c0bf6bdf4ab3