### PR TITLE
Fix asset paths in latinphone page

### DIFF
--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <script src="repair.js"></script>
+  <script src="./repair.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>LatinPhone - Tecnología Premium</title>
@@ -16,12 +16,12 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- CSS Principal -->
-    <link rel="stylesheet" href="latinphone.css">
+    <link rel="stylesheet" href="./latinphone.css">
     
     <!-- Scripts -->
     <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js" defer></script>
-  <link rel="stylesheet" href="responsive.css">
+  <link rel="stylesheet" href="./responsive.css">
 </head>
 <body>
     <!-- Header Navegación Fijo -->
@@ -895,8 +895,8 @@
     </div>
 
     <!-- JavaScript -->
-    <script src="latinphone.js" defer></script>
+    <script src="./latinphone.js" defer></script>
 <div id="bottom-nav-container"></div>
-<script src="bottom-nav.js"></script>
+<script src="./bottom-nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use relative paths for `latinphone` assets

## Testing
- `curl -I http://localhost:8000/latinphone.html`
- `curl -I http://localhost:8000/latinphone.css`
- `curl -I http://localhost:8000/latinphone.js`


------
https://chatgpt.com/codex/tasks/task_e_685e32ec07708324b0872cfa6c84958e