### PR TITLE
Remove bottom nav from LatinPhone page

### DIFF
--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -896,7 +896,5 @@
 
     <!-- JavaScript -->
     <script src="./latinphone.js" defer></script>
-<div id="bottom-nav-container"></div>
-<script src="./bottom-nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove bottom-nav container and script from `latinphone.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e3518f1fc8324bc77315c4df14eed