### PR TITLE
Fix mobile responsiveness for latinphone

### DIFF
--- a/public/latinphone.css
+++ b/public/latinphone.css
@@ -2945,6 +2945,26 @@ body {
     }
 }
 
+@media (max-width: 480px) {
+    .hero-section {
+        height: 50vh;
+        min-height: 340px;
+    }
+
+    .hero-content {
+        padding: var(--space-4) var(--space-3);
+    }
+
+    .hero-title-main,
+    .hero-title-accent {
+        font-size: clamp(1.8rem, 8vw, 2.2rem);
+    }
+
+    .progress-section {
+        padding: 0 var(--space-4);
+    }
+}
+
 /* Utility Classes */
 .sr-only {
     position: absolute;

--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -3,7 +3,7 @@
 <head>
   <script src="./repair.js"></script>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LatinPhone - Tecnología Premium</title>
     
     <!-- Google Fonts - Apple-style typography -->


### PR DESCRIPTION
## Summary
- ensure responsive meta tag uses modern values
- tweak layout on very small screens

## Testing
- `npm test` *(fails: Missing script and registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685e38b826b8832499c4679208e07726