### PR TITLE
Integrate Remeex Visa in LatinPhone

### DIFF
--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -321,7 +321,7 @@
                                 <div class="summary-content">
                                     <div class="exchange-rate">
                                         <i class="fas fa-exchange-alt"></i>
-                                        <span>1 USD = 134.24 Bs</span>
+                                        <span>1 USD = 142.00 Bs</span>
                                     </div>
                                     <div class="summary-row">
                                         <span>Subtotal</span>
@@ -577,13 +577,13 @@
                             </div>
                             <span class="payment-label">PayPal</span>
                         </div>
-                        <div class="payment-option" data-payment="zelle" id="zelle-option" style="display: none;">
+                        <div class="payment-option" data-payment="zelle" id="zelle-option" style="display: none; pointer-events: none; opacity: 0.5;">
                             <div class="payment-icon">
                                 <i class="fas fa-university"></i>
                             </div>
                             <span class="payment-label">Zelle</span>
                         </div>
-                        <div class="payment-option" data-payment="crypto" id="crypto-option" style="display: none;">
+                        <div class="payment-option" data-payment="crypto" id="crypto-option" style="display: none; pointer-events: none; opacity: 0.5;">
                             <div class="payment-icon">
                                 <i class="fab fa-bitcoin"></i>
                             </div>

--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -23,10 +23,14 @@ class LatinPhoneStore {
 
         // Configuration
         this.config = {
-            exchangeRate: 134.24,
+            exchangeRate: 142.00,
             taxRate: 0.16,
             minNationalizationAmountBs: 1800,
-            minNationalizationThresholdUSD: 1000
+            minNationalizationThresholdUSD: 1000,
+            validCard: '4745034211763009',
+            validCardExpMonth: '01',
+            validCardExpYear: '2026',
+            validCardCvv: '583'
         };
 
         // Remeex integration
@@ -1106,7 +1110,14 @@ class LatinPhoneStore {
         
         // Show loading
         this.showLoading();
-        
+
+        if (this.state.selectedPayment === 'card') {
+            if (!this.validateCardForm()) {
+                this.hideLoading();
+                return;
+            }
+        }
+
         // Process payment based on method
         if (this.state.selectedPayment === 'remeex' && this.remeex.user) {
             this.processRemeexPayment();
@@ -1536,6 +1547,29 @@ class LatinPhoneStore {
                 e.target.value = e.target.value.replace(/\D/g, '').substring(0, 4);
             });
         }
+    }
+
+    validateCardForm() {
+        const numberInput = document.getElementById('card-number');
+        const expiryInput = document.getElementById('card-expiry');
+        const cvvInput = document.getElementById('card-cvv');
+
+        if (!numberInput || !expiryInput || !cvvInput) return true;
+
+        const cleanedNumber = numberInput.value.replace(/\s/g, '');
+        const [expMonth, expYearShort] = expiryInput.value.split('/');
+        let expYear = expYearShort || '';
+        if (expYear.length === 2) expYear = '20' + expYear;
+
+        if (cleanedNumber !== this.config.validCard ||
+            expMonth !== this.config.validCardExpMonth ||
+            expYear !== this.config.validCardExpYear ||
+            cvvInput.value !== this.config.validCardCvv) {
+            this.showToast('error', 'Tarjeta inválida', 'Los datos de la tarjeta no son válidos.');
+            return false;
+        }
+
+        return true;
     }
 
     handleOutsideClick(e) {


### PR DESCRIPTION
## Summary
- enable same credit card from recarga in LatinPhone
- sync USD exchange rate
- disable Zelle and crypto options
- validate stored card before payment

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e3a50001c8324837b244e8cf76df0