### PR TITLE
Enable saved card payments in LatinPhone

### DIFF
--- a/public/latinphone.css
+++ b/public/latinphone.css
@@ -1904,6 +1904,60 @@ body {
     color: var(--gray-400);
 }
 
+/* Saved Card */
+.saved-card-container {
+    display: none;
+    background: var(--gray-100);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    margin-bottom: var(--space-6);
+}
+
+.saved-card {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.saved-card-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-full);
+    background: var(--primary-500);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--text-lg);
+}
+
+.saved-card-details {
+    flex: 1;
+}
+
+.saved-card-number {
+    font-weight: 600;
+    font-size: var(--text-sm);
+    color: var(--gray-900);
+}
+
+.saved-card-type {
+    font-size: var(--text-xs);
+    color: var(--gray-500);
+}
+
+.saved-card-use {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.saved-card-checkbox {
+    width: 18px;
+    height: 18px;
+}
+
 /* Payment Summary */
 .payment-summary {
     background: white;

--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -591,6 +591,23 @@
                         </div>
                     </div>
 
+                    <!-- Saved Card Container -->
+                    <div class="saved-card-container" id="saved-card-container">
+                        <div class="saved-card">
+                            <div class="saved-card-icon">
+                                <i class="fab fa-cc-visa"></i>
+                            </div>
+                            <div class="saved-card-details">
+                                <div class="saved-card-number">•••• •••• •••• 3009</div>
+                                <div class="saved-card-type">VISA</div>
+                            </div>
+                            <div class="saved-card-use">
+                                <input type="checkbox" id="use-saved-card" class="saved-card-checkbox" checked>
+                                <label for="use-saved-card">Usar esta tarjeta</label>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Card Form -->
                     <div class="payment-form" id="card-form">
                         <div class="form-group">

--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -117,6 +117,8 @@ class LatinPhoneStore {
         // Payment elements
         this.paymentOptions = document.querySelectorAll('.payment-option');
         this.paymentForm = document.getElementById('card-form');
+        this.savedCardContainer = document.getElementById('saved-card-container');
+        this.useSavedCardCheckbox = document.getElementById('use-saved-card');
         this.paymentSummaryItems = document.getElementById('payment-summary-items');
 
         // Navigation buttons
@@ -226,6 +228,18 @@ class LatinPhoneStore {
 
         // Form validation
         this.setupFormValidation();
+
+        if (this.useSavedCardCheckbox) {
+            this.useSavedCardCheckbox.addEventListener('change', () => {
+                if (this.useSavedCardCheckbox.checked) {
+                    if (this.paymentForm) this.paymentForm.style.display = 'none';
+                } else {
+                    if (this.paymentForm && this.state.selectedPayment === 'card') {
+                        this.paymentForm.style.display = 'block';
+                    }
+                }
+            });
+        }
 
         // Close modals
         const closeButtons = document.querySelectorAll('[id*="close"]');
@@ -493,6 +507,8 @@ class LatinPhoneStore {
                     this.remeex.hasSavedCard = parsedCard.hasSavedCard || false;
                 }
 
+                this.updateSavedCardUI();
+
                 this.displayRemeexPaymentOption();
                 this.updateOrderSummary();
             }
@@ -520,6 +536,21 @@ class LatinPhoneStore {
 
         remeexOption.addEventListener('click', () => this.selectPaymentMethod('remeex'));
         paymentOptionsContainer.insertBefore(remeexOption, paymentOptionsContainer.firstChild);
+    }
+
+    updateSavedCardUI() {
+        if (!this.savedCardContainer) return;
+        if (this.remeex.hasSavedCard) {
+            this.savedCardContainer.style.display = 'block';
+            if (this.useSavedCardCheckbox && this.useSavedCardCheckbox.checked) {
+                if (this.paymentForm) this.paymentForm.style.display = 'none';
+            }
+        } else {
+            this.savedCardContainer.style.display = 'none';
+            if (this.paymentForm && this.state.selectedPayment === 'card') {
+                this.paymentForm.style.display = 'block';
+            }
+        }
     }
 
     selectCountry(country) {
@@ -997,6 +1028,9 @@ class LatinPhoneStore {
         // Show/hide payment form based on method
         if (this.paymentForm) {
             this.paymentForm.style.display = method === 'card' ? 'block' : 'none';
+            if (method === 'card' && this.useSavedCardCheckbox && this.useSavedCardCheckbox.checked) {
+                this.paymentForm.style.display = 'none';
+            }
         }
         
         this.showToast('info', 'Método de pago', 
@@ -1555,6 +1589,10 @@ class LatinPhoneStore {
         const cvvInput = document.getElementById('card-cvv');
 
         if (!numberInput || !expiryInput || !cvvInput) return true;
+
+        if (this.useSavedCardCheckbox && this.useSavedCardCheckbox.checked && this.remeex.hasSavedCard) {
+            return true;
+        }
 
         const cleanedNumber = numberInput.value.replace(/\s/g, '');
         const [expMonth, expYearShort] = expiryInput.value.split('/');


### PR DESCRIPTION
## Summary
- add saved card selection UI in `latinphone.html`
- style saved card components in `latinphone.css`
- integrate saved card logic in `latinphone.js`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e3c7bc61c8324a1a234ec1212967f