### PR TITLE
Improve cart management in LatinPhone

### DIFF
--- a/public/latinphone.css
+++ b/public/latinphone.css
@@ -1156,6 +1156,28 @@ body {
     transform: none;
 }
 
+.clear-cart-btn {
+    width: 100%;
+    height: 2.5rem;
+    margin-top: var(--space-4);
+    background: var(--error);
+    color: white;
+    border: none;
+    border-radius: var(--radius-lg);
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    transition: all var(--transition-base);
+}
+
+.clear-cart-btn:hover {
+    background: #dc2626;
+    transform: translateY(-1px);
+}
+
 /* Gift Section */
 .gift-section {
     margin-bottom: var(--space-16);

--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -351,6 +351,10 @@
                                         <span>Continuar</span>
                                         <i class="fas fa-arrow-right"></i>
                                     </button>
+                                    <button class="clear-cart-btn" id="clear-cart">
+                                        <i class="fas fa-trash"></i>
+                                        <span>Vaciar carrito</span>
+                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -59,6 +59,7 @@ class LatinPhoneStore {
         this.updateCartBadge();
         this.setupDefaultSelections();
         this.loadPurchases();
+        this.loadCart();
         this.renderPurchases();
         this.checkPurchaseLimit();
         this.autofillContactForm();
@@ -97,6 +98,7 @@ class LatinPhoneStore {
         this.insuranceElement = document.getElementById('insurance');
         this.totalElement = document.getElementById('total');
         this.totalBsElement = document.getElementById('total-bs');
+        this.clearCartBtn = document.getElementById('clear-cart');
 
         // Shipping elements
         this.shippingOptions = document.querySelectorAll('.shipping-option');
@@ -215,6 +217,10 @@ class LatinPhoneStore {
 
         if (this.processPaymentBtn) {
             this.processPaymentBtn.addEventListener('click', () => this.processPayment());
+        }
+
+        if (this.clearCartBtn) {
+            this.clearCartBtn.addEventListener('click', () => this.clearCart());
         }
 
         const downloadBtn = document.getElementById('download-invoice');
@@ -722,6 +728,7 @@ class LatinPhoneStore {
 
         this.updateCartDisplay();
         this.updateCartBadge();
+        this.saveCart();
         this.cartSection.style.display = 'block';
         this.scrollToElement(this.cartSection);
 
@@ -824,6 +831,7 @@ class LatinPhoneStore {
                 item.quantity = newQuantity;
                 this.updateCartDisplay();
                 this.updateCartBadge();
+                this.saveCart();
             }
         }
     }
@@ -834,6 +842,7 @@ class LatinPhoneStore {
             item.quantity = quantity;
             this.updateCartDisplay();
             this.updateCartBadge();
+            this.saveCart();
         }
     }
 
@@ -844,8 +853,18 @@ class LatinPhoneStore {
             this.state.cart.splice(itemIndex, 1);
             this.updateCartDisplay();
             this.updateCartBadge();
+            this.saveCart();
             this.showToast('info', 'Producto eliminado', `${removedItem.name} eliminado del carrito`);
         }
+    }
+
+    clearCart() {
+        if (this.state.cart.length === 0) return;
+        this.state.cart = [];
+        this.updateCartDisplay();
+        this.updateCartBadge();
+        this.saveCart();
+        this.showToast('info', 'Carrito vaciado', 'Se eliminaron todos los productos de tu carrito');
     }
 
     updateCartBadge() {
@@ -1696,8 +1715,23 @@ class LatinPhoneStore {
         }
     }
 
+    loadCart() {
+        try {
+            const data = JSON.parse(localStorage.getItem('latinphoneCart') || '[]');
+            this.state.cart = Array.isArray(data) ? data : [];
+        } catch (e) {
+            this.state.cart = [];
+        }
+        this.updateCartDisplay();
+        this.updateCartBadge();
+    }
+
     savePurchases() {
         localStorage.setItem('latinphonePurchases', JSON.stringify(this.purchases));
+    }
+
+    saveCart() {
+        localStorage.setItem('latinphoneCart', JSON.stringify(this.state.cart));
     }
 
     renderPurchases() {
@@ -1735,6 +1769,7 @@ class LatinPhoneStore {
         this.renderPurchases();
         this.checkPurchaseLimit();
         this.lastPurchase = purchase;
+        this.clearCart();
     }
 
     checkPurchaseLimit() {


### PR DESCRIPTION
## Summary
- add button to clear cart in `latinphone.html`
- style new clear-cart button
- persist cart with localStorage and allow clearing
- empty cart after successful purchase

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e3f3c15b083249e4a52ed2ea5eafc