### PR TITLE
Fix close buttons overlay on recarga.html videos

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -4622,6 +4622,7 @@
       display: none;
       justify-content: center;
       align-items: center;
+      flex-direction: column;
       opacity: 0;
       transition: opacity 0.5s ease;
     }
@@ -4642,10 +4643,7 @@
     }
 
     .welcome-video-close {
-      position: absolute;
-      bottom: 20px;
-      left: 50%;
-      transform: translateX(-50%) scale(0);
+      margin-top: 20px;
       padding: 10px 20px;
       border-radius: 30px;
       background: rgba(255, 255, 255, 0.9);
@@ -4659,17 +4657,18 @@
       z-index: 10;
       transition: all 0.3s ease;
       opacity: 0;
+      transform: scale(0);
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
     }
 
     .welcome-video-close.visible {
       opacity: 1;
-      transform: translateX(-50%) scale(1);
+      transform: scale(1);
     }
 
     .welcome-video-close:hover {
       background: rgba(255, 255, 255, 1);
-      transform: translateX(-50%) scale(1.05);
+      transform: scale(1.05);
       box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
     }
 
@@ -6448,9 +6447,9 @@
                 style="position:absolute;top:0;left:0;width:100%;height:100%;"
                 title="visa"></iframe>
       </div>
-      <div class="welcome-video-close" id="welcome-video-close">
-        <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
-      </div>
+    </div>
+    <div class="welcome-video-close" id="welcome-video-close">
+      <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
     </div>
   </div>
   <script src="https://player.vimeo.com/api/player.js"></script>
@@ -6465,9 +6464,9 @@
                 style="position:absolute;top:0;left:0;width:100%;height:100%;"
                 title="visa"></iframe>
       </div>
-      <div class="welcome-video-close" id="card-video-close">
-        <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
-      </div>
+    </div>
+    <div class="welcome-video-close" id="card-video-close">
+      <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
     </div>
   </div>
   <div class="welcome-video-overlay" id="validation-video-overlay">
@@ -6480,9 +6479,9 @@
                 style="position:absolute;top:0;left:0;width:100%;height:100%;"
                 title="visa"></iframe>
       </div>
-      <div class="welcome-video-close" id="validation-video-close">
-        <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
-      </div>
+    </div>
+    <div class="welcome-video-close" id="validation-video-close">
+      <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
     </div>
   </div>
   <div class="welcome-video-overlay" id="services-video-overlay">
@@ -6494,9 +6493,9 @@
                 style="position:absolute;top:0;left:0;width:100%;height:100%;"
                 title="visa"></iframe>
       </div>
-      <div class="welcome-video-close" id="services-video-close">
-        <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
-      </div>
+    </div>
+    <div class="welcome-video-close" id="services-video-close">
+      <i class="fas fa-times" style="margin-right:5px;"></i> Cerrar
     </div>
   </div>
   <script src="https://player.vimeo.com/api/player.js"></script>


### PR DESCRIPTION
## Summary
- reposition close buttons so they appear below the video frame
- adjust overlay layout to stack video and button vertically

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e420d3df883249b02bbdfb88372c7