### PR TITLE
Select premium insurance by default

### DIFF
--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -337,7 +337,7 @@
                                     </div>
                                     <div class="summary-row">
                                         <span>Seguro</span>
-                                        <span id="insurance">$0.00</span>
+                                        <span id="insurance">$50.00</span>
                                     </div>
                                     <div class="summary-divider"></div>
                                     <div class="summary-row total">
@@ -484,7 +484,7 @@
                     </div>
 
                     <div class="insurance-options">
-                        <div class="insurance-option" data-insurance="true" data-price="50">
+                        <div class="insurance-option selected" data-insurance="true" data-price="50">
                             <div class="insurance-radio">
                                 <div class="radio-dot"></div>
                             </div>
@@ -505,7 +505,7 @@
                             </div>
                         </div>
 
-                        <div class="insurance-option selected" data-insurance="false" data-price="0">
+                        <div class="insurance-option" data-insurance="false" data-price="0">
                             <div class="insurance-radio">
                                 <div class="radio-dot"></div>
                             </div>

--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -14,7 +14,7 @@ class LatinPhoneStore {
             cart: [],
             selectedShipping: { method: 'express', price: 70 },
             selectedCarrier: 'dhl',
-            selectedInsurance: { selected: false, price: 0 },
+            selectedInsurance: { selected: true, price: 50 },
             selectedGift: null,
             selectedPayment: 'card',
             orderNumber: '',
@@ -464,10 +464,10 @@ class LatinPhoneStore {
             expressOption.classList.add('selected');
         }
 
-        // Set default insurance (No insurance)
-        const noInsuranceOption = document.querySelector('.insurance-option[data-insurance="false"]');
-        if (noInsuranceOption) {
-            noInsuranceOption.classList.add('selected');
+        // Set default insurance (Premium)
+        const premiumInsuranceOption = document.querySelector('.insurance-option[data-insurance="true"]');
+        if (premiumInsuranceOption) {
+            premiumInsuranceOption.classList.add('selected');
         }
 
         // Set default payment method


### PR DESCRIPTION
## Summary
- set premium insurance as the default selection in `latinphone.html`
- update cart summary default insurance amount
- configure JS state and defaults for premium insurance

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685e4184286c8324a2796557d69950f1