### PR TITLE
Fix login redirect to recarga subdomain

### DIFF
--- a/public/registro.html
+++ b/public/registro.html
@@ -2281,7 +2281,7 @@ function setupCardClickEvents() {
                     const data = JSON.parse(saved);
                     if (data.completed) {
                         // Redirigir directamente a recarga
-                        window.location.href = 'recarga';
+                        window.location.href = 'https://home.remeexvisa.com/recarga';
                         return;
                     }
                 } catch (e) {
@@ -3548,7 +3548,7 @@ function setupCardClickEvents() {
         }
 
         function goToLogin() {
-            window.location.href = 'recarga';
+            window.location.href = 'https://home.remeexvisa.com/recarga';
         }
 
         function exitRegistration() {


### PR DESCRIPTION
## Summary
- update `goToLogin` and registration resume redirect to use the `home.remeexvisa.com/recarga` path

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ed2ed4a1c8324b8f18dca46c20140