### PR TITLE
Fix redirect from recarga.html to clean URL

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,8 +5,8 @@
   "outputDirectory": "public",
   "redirects": [
     {
-      "source": "/:path+.html",
-      "destination": "/:path",
+      "source": "/(.*).html",
+      "destination": "/$1",
       "statusCode": 301
     }
   ]


### PR DESCRIPTION
## Summary
- tweak Vercel redirect rule so visiting `/recarga.html` shows `/recarga`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ed496667c8324bc7a612ebcefa028