### PR TITLE
Improve LatinPhone success flow

### DIFF
--- a/public/latinphone.css
+++ b/public/latinphone.css
@@ -2450,6 +2450,24 @@ body {
     margin-bottom: var(--space-6);
 }
 
+.purchase-success-order {
+    font-weight: 600;
+    color: var(--gray-700);
+    margin-bottom: var(--space-6);
+}
+
+.purchase-success-history {
+    display: inline-block;
+    margin-top: var(--space-4);
+    color: var(--primary-600);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.purchase-success-history:hover {
+    color: var(--primary-700);
+}
+
 .purchase-success-btn {
     background: var(--primary-600);
     color: white;

--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -932,10 +932,12 @@
             </div>
             <div class="purchase-success-title">¡Compra exitosa!</div>
             <div class="purchase-success-message">Tu pago fue procesado correctamente.</div>
+            <div class="purchase-success-order">Orden <span id="success-order-number"></span></div>
             <button class="purchase-success-btn" id="purchase-success-continue">
                 <i class="fas fa-receipt"></i>
                 <span>Ver detalle</span>
             </button>
+            <a href="#mis-compras" class="purchase-success-history">Ir a Mis Compras</a>
         </div>
     </div>
 

--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -1844,6 +1844,8 @@ class LatinPhoneStore {
 
     showSuccessOverlay() {
         if (this.successOverlay) {
+            const orderNumEl = document.getElementById('success-order-number');
+            if (orderNumEl) orderNumEl.textContent = this.state.orderNumber;
             this.successOverlay.style.display = 'flex';
         }
     }
@@ -1852,6 +1854,8 @@ class LatinPhoneStore {
         if (this.successOverlay) {
             this.successOverlay.style.display = 'none';
         }
+        const section = document.getElementById('section-4');
+        if (section) this.scrollToElement(section, -100);
     }
 
     sendOrderToWhatsApp() {


### PR DESCRIPTION
## Summary
- enhance purchase success overlay with order number and history link
- style new elements
- update JS to display order number and scroll to confirmation section

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685edb433f4c8324bc668194fd2d89fe