### PR TITLE
Enhance order timeline and invoice details

### DIFF
--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -750,16 +750,34 @@
                                     </div>
                                     <div class="timeline-content">
                                         <h4>Pago confirmado</h4>
-                                        <p>20 Mar 2025</p>
+                                        <p id="paid-date">--</p>
                                     </div>
                                 </div>
                                 <div class="timeline-step">
                                     <div class="timeline-circle">
-                                        <i class="fas fa-box"></i>
+                                        <i class="fas fa-box-open"></i>
                                     </div>
                                     <div class="timeline-content">
-                                        <h4>Preparando pedido</h4>
-                                        <p id="delivery-date-start">21 Mar 2025</p>
+                                        <h4>Empaquetado</h4>
+                                        <p id="packaging-date">--</p>
+                                    </div>
+                                </div>
+                                <div class="timeline-step">
+                                    <div class="timeline-circle">
+                                        <i class="fas fa-ship"></i>
+                                    </div>
+                                    <div class="timeline-content">
+                                        <h4>Enviado a puerto</h4>
+                                        <p id="port-date">--</p>
+                                    </div>
+                                </div>
+                                <div class="timeline-step">
+                                    <div class="timeline-circle">
+                                        <i class="fas fa-plane"></i>
+                                    </div>
+                                    <div class="timeline-content">
+                                        <h4>Enviado por <span id="carrier-name">DHL</span></h4>
+                                        <p id="shipped-date">--</p>
                                     </div>
                                 </div>
                                 <div class="timeline-step">
@@ -768,7 +786,7 @@
                                     </div>
                                     <div class="timeline-content">
                                         <h4>En tránsito</h4>
-                                        <p id="delivery-date-transit">22 Mar 2025</p>
+                                        <p id="delivery-date-transit">--</p>
                                     </div>
                                 </div>
                                 <div class="timeline-step">
@@ -777,7 +795,7 @@
                                     </div>
                                     <div class="timeline-content">
                                         <h4>Entrega estimada</h4>
-                                        <p><span id="delivery-date-start-2">23 Mar</span> - <span id="delivery-date-end">25 Mar 2025</span></p>
+                                        <p><span id="delivery-date-start-2">--</span> - <span id="delivery-date-end">--</span></p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- extend shipping timeline in `latinphone.html`
- dynamically update new timeline dates and carrier name in `latinphone.js`
- record order items and shipping info when registering purchases
- generate a complete invoice with company and user data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ee0ddf8548324b232649a680d890e