### PR TITLE
Allow .html and extensionless pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Se agregó la página `ajustes` que presenta un panel completo para gestionar la
 
 ## Enlaces sin extensión
 
-El proyecto está configurado en Vercel con `cleanUrls` para servir las páginas
-sin la terminación `.html`. Los enlaces internos apuntan a rutas como `recarga`,
-`ajustes` o `transferencia` en lugar de `recarga.html`. Si navegas de manera
-local abre los archivos `.html` directamente o añade la extensión en la barra
-de direcciones.
+El proyecto está configurado en Vercel con `cleanUrls` y una regla de
+`rewrites` para que cada página funcione tanto con la terminación `.html` como
+sin ella. Los enlaces internos apuntan a rutas como `recarga`, `ajustes` o
+`transferencia`, pero acceder a `recarga.html` o `recarga` mostrará el mismo
+contenido. Si navegas de manera local puedes abrir los archivos con su
+extensión `.html` o sin ella si cuentas con un servidor que maneje estas
+rewrites.

--- a/vercel.json
+++ b/vercel.json
@@ -3,11 +3,10 @@
   "version": 2,
   "cleanUrls": true,
   "outputDirectory": "public",
-  "redirects": [
+  "rewrites": [
     {
       "source": "/(.*).html",
-      "destination": "/$1",
-      "statusCode": 301
+      "destination": "/$1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- keep pages accessible both with `.html` and without
- document new rewrite rule in README

## Testing
- `npm run build`
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ee3d7ab8c83249c931586db8df730