### PR TITLE
Add LatinPhone logo to transactions

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -6833,7 +6833,7 @@
       window.location.href = "https://visa.es";
     }
 
-    const BANK_NAME_MAP = {
+const BANK_NAME_MAP = {
       banesco: 'Banesco',
       mercantil: 'Mercantil',
       venezuela: 'Banco de Venezuela',
@@ -6853,6 +6853,9 @@
       mi_banco: 'Mi Banco',
       otros: 'Otros'
     };
+
+    const LATINPHONE_LOGO =
+      'https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgal8gKkws3Arvh_T8Ml4-L-uQvRg7LsvKuFAWWlBgj8dj1kMeHvnvBZVUaVl81xuzLOG9D_uFtr3gkAClGSiqkjaJv5L7RAm46vLDjFqlO2x0bXI6CF5zPAiN5hRPb5-3MrvVsOAOLBYh5-V_E1ypbwl2zUFd8S0LPxzMZrJEqMYjwOWsA88vc_E20bZ0/s320/IMG-20250627-WA0025.png';
 
     // Global variables
     let currentUser = {
@@ -11958,6 +11961,12 @@ function setupUsAccountLink() {
           <div class="transaction-category">
             <img src="${safeLogo}" alt="${safeBank}" class="transaction-bank-logo">
             ${bankText}
+          </div>
+        `;
+      } else if (transaction.description && transaction.description.toLowerCase().includes('latinphone')) {
+        transactionHTML += `
+          <div class="transaction-category">
+            <img src="${LATINPHONE_LOGO}" alt="LatinPhone" class="transaction-bank-logo">
           </div>
         `;
       }


### PR DESCRIPTION
## Summary
- show LatinPhone logo beside purchases in recarga.html

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ee326984c8324a87b97d63a67050b