### PR TITLE
Improve desktop readability on recarga page

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -4774,6 +4774,14 @@
 
   </style>
   <link rel="stylesheet" href="responsive.css">
+  <style>
+    html {
+      font-size: 72%;
+    }
+    @media (min-width: 768px) {
+      html { font-size: 100%; }
+    }
+  </style>
   <link rel="stylesheet" href="theme.css">
 </head>
 


### PR DESCRIPTION
## Summary
- increase default font size on `recarga.html`

## Testing
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ef0a48630832491355677d61bed15