### PR TITLE
Fix progress bar styles in verificacion page

### DIFF
--- a/public/verificacion.html
+++ b/public/verificacion.html
@@ -24,6 +24,12 @@
       --danger: #ff4d4d;
       --warning: #ffad33;
       --info: #0095ff;
+      --visa-blue: #1a1f71;
+      --visa-blue-light: #3b4998;
+      --visa-blue-dark: #0d1142;
+      --visa-gold: #f7b500;
+      --text-primary: #1a1f71;
+      --border: #e2e8f0;
       --neutral-50: #fafbfc;
       --neutral-100: #ffffff;
       --neutral-200: #f5f7fa;


### PR DESCRIPTION
## Summary
- define missing CSS variables in `verificacion.html` so its progress bar matches other pages

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ef93019bc83249834facbe17286d8