### PR TITLE
Fix wizard text overlap

### DIFF
--- a/public/transferencia.html
+++ b/public/transferencia.html
@@ -430,6 +430,8 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+      flex-wrap: wrap;
+      gap: 0.25rem;
     }
 
     .progress-percentage-wizard {
@@ -545,11 +547,13 @@
       font-weight: 700;
       color: var(--neutral-900);
       margin-bottom: 0.5rem;
+      word-break: break-word;
     }
 
     .step-subtitle {
       font-size: 0.9rem;
       color: var(--neutral-600);
+      word-break: break-word;
     }
 
     /* Method Selection Grid */


### PR DESCRIPTION
## Summary
- allow wrapping for wizard progress info
- prevent long step titles from overlapping

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ef96d13248324b241d19cc9750eba