### PR TITLE
Fix purchase success overlay trigger

### DIFF
--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -1370,7 +1370,9 @@ class LatinPhoneStore {
     }
 
     closeModals() {
+        let closedNationalization = false;
         if (this.nationalizationOverlay) {
+            closedNationalization = this.nationalizationOverlay.classList.contains('active');
             this.nationalizationOverlay.classList.remove('active');
         }
         
@@ -1383,7 +1385,7 @@ class LatinPhoneStore {
         }
         
         // Continue to success after closing nationalization modal
-        if (this.nationalizationOverlay && this.nationalizationOverlay.classList.contains('active')) {
+        if (closedNationalization) {
             setTimeout(() => {
                 this.goToStep(4);
                 this.updateOrderDetails();


### PR DESCRIPTION
## Summary
- ensure success overlay is shown after closing nationalization modal

## Testing
- `npm run build`
- `timeout 5 npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685f22c24e0883249ce0cf7e79710a35