### PR TITLE
Increase base font size in recarga page

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -96,7 +96,7 @@
     
     body {
       font-family: 'Inter', 'Roboto', system-ui, sans-serif;
-      font-size: 0.875rem; /* = 14px */
+      font-size: 1.05rem; /* = 16.8px (20% increase) */
       color: #1f2937;
       background: var(--neutral-200);
       line-height: 1.5;
@@ -3507,7 +3507,7 @@
 }
 
 .verificacion-descripcion {
-  font-size: 0.875rem;
+  font-size: 1.05rem;
   color: var(--neutral-600);
   margin-bottom: 0.75rem;
   font-family: inherit;


### PR DESCRIPTION
## Summary
- enlarged default font-size in **recarga.html** by 20%

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f23552eb48324a44d208a13bd23cf