### PR TITLE
Fix exchange history persistence

### DIFF
--- a/public/intercambio.html
+++ b/public/intercambio.html
@@ -1960,8 +1960,6 @@
       loadUserData();
       loadExchangeRate();
       loadExchangeHistory();
-      exchangeHistory = [];
-      saveExchangeHistory();
       loadTemplates();
       updateBalanceDisplay();
       renderHistory();


### PR DESCRIPTION
## Summary
- fix exchange history initialization so localStorage data isn't cleared

## Testing
- `npm start` *(fails: no tests, just starts server)*

------
https://chatgpt.com/codex/tasks/task_e_685fba4ade308324b3dc6937582976bf