### PR TITLE
Fix Mi Estatus redirect in recarga page

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -10161,7 +10161,7 @@ function stopVerificationProgress() {
 
       if (statusBtn) {
         statusBtn.addEventListener('click', function() {
-          window.location.href = 'verificacion.html';
+          window.location.href = 'miestatus.html';
           resetInactivityTimer();
         });
       }


### PR DESCRIPTION
## Summary
- update the handler for the **Mi Estatus** button so it routes to `miestatus.html`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685fc90701048324b1027cfb0bda7b2c