### PR TITLE
Fix redirect from registro to recarga page

### DIFF
--- a/public/registro.html
+++ b/public/registro.html
@@ -2282,7 +2282,7 @@ function setupCardClickEvents() {
                     const data = JSON.parse(saved);
                     if (data.completed) {
                         // Redirigir directamente a recarga
-                        window.location.href = '';
+                        window.location.href = 'recarga';
                         return;
                     }
                 } catch (e) {
@@ -3550,7 +3550,7 @@ function setupCardClickEvents() {
 
         function goToLogin() {
             sessionStorage.setItem('fromRegistro', 'true');
-            window.location.href = '';
+            window.location.href = 'recarga';
         }
 
         function exitRegistration() {


### PR DESCRIPTION
## Summary
- ensure registro.html sends the user to the recarga page when the registration is done or previously completed

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fda1edc48832490be084cb280e0b6