### PR TITLE
Fix success overlay logic in LatinPhone

### DIFF
--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -1370,10 +1370,13 @@ class LatinPhoneStore {
     }
 
     closeModals() {
+        const wasNationalizationActive = this.nationalizationOverlay &&
+            this.nationalizationOverlay.classList.contains('active');
+
         if (this.nationalizationOverlay) {
             this.nationalizationOverlay.classList.remove('active');
         }
-        
+
         if (this.videoModal) {
             this.videoModal.classList.remove('active');
             if (this.productVideo) {
@@ -1381,14 +1384,12 @@ class LatinPhoneStore {
                 this.productVideo.src = '';
             }
         }
-        
-        // Continue to success after closing nationalization modal
-        if (this.nationalizationOverlay && this.nationalizationOverlay.classList.contains('active')) {
+
+        if (wasNationalizationActive) {
             setTimeout(() => {
                 this.goToStep(4);
                 this.updateOrderDetails();
-                
-                // Show confetti
+
                 if (window.confetti) {
                     confetti({
                         particleCount: 150,


### PR DESCRIPTION
## Summary
- properly check if the nationalization modal was active before closing it in `closeModals`

## Testing
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686012421d8883248de3140a96e03661