### PR TITLE
Fix Mi Estatus button link

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -10165,7 +10165,7 @@ function stopVerificationProgress() {
 
       if (statusBtn) {
         statusBtn.addEventListener('click', function() {
-          window.location.href = 'miestatus.html';
+          window.location.href = 'estatus.hml';
           resetInactivityTimer();
         });
       }


### PR DESCRIPTION
## Summary
- update the `Mi Estatus` button to link to **estatus.hml**

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686024135da4832492849a11503fc014