### PR TITLE
Fix limit check for withdrawal amount

### DIFF
--- a/public/transferencia.html
+++ b/public/transferencia.html
@@ -4967,7 +4967,6 @@ let selectedCurrency = 'bs'; // Para input de monto
         withdrawalAmountEur = withdrawalAmountUsd * CONFIG.EXCHANGE_RATES.USD_TO_EUR;
         updateEquivalentsDisplay();
         saveTransferData();
-        checkWithdrawalLimits();
 
         // Validar para habilitar botón siguiente
         updateNextButtonState();
@@ -4978,6 +4977,7 @@ let selectedCurrency = 'bs'; // Para input de monto
           const displayAmount = selectedCurrency === 'usd' ? withdrawalAmountUsd : withdrawalAmount;
           this.value = formatNumberWithCommas(displayAmount);
         }
+        checkWithdrawalLimits();
       });
     }
 
@@ -5908,11 +5908,11 @@ let selectedCurrency = 'bs'; // Para input de monto
           withdrawalAmountEur = withdrawalAmountUsd * CONFIG.EXCHANGE_RATES.USD_TO_EUR;
           updateEquivalentsDisplay();
           saveTransferData();
-          checkWithdrawalLimits();
         });
 
       amountInput.addEventListener('blur', function() {
         this.value = withdrawalAmount ? formatNumberWithCommas(withdrawalAmount) : '';
+        checkWithdrawalLimits();
       });
 
       const event = new Event('input');


### PR DESCRIPTION
## Summary
- postpone validation of withdrawal limits until the amount field loses focus
- still parse typed numbers without separators to the expected decimal format

## Testing
- `npm run build`
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6860403f57688324a8c4aff5e55ec9d5