### PR TITLE
Fix order detail totals

### DIFF
--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -731,6 +731,14 @@
                                     <span class="detail-value" id="order-total">$0.00</span>
                                 </div>
                                 <div class="detail-row">
+                                    <span class="detail-label">Nacionalización pendiente</span>
+                                    <span class="detail-value" id="nationalization-amount">0.00 Bs</span>
+                                </div>
+                                <div class="detail-row">
+                                    <span class="detail-label">Tasa de cambio</span>
+                                    <span class="detail-value" id="order-exchange-rate">1 USD = 0.00 Bs</span>
+                                </div>
+                                <div class="detail-row">
                                     <span class="detail-label">Envío</span>
                                     <span class="detail-value" id="shipping-method">Express (1-4 días)</span>
                                 </div>

--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -1437,14 +1437,25 @@ class LatinPhoneStore {
         const subtotalEl = document.getElementById('order-subtotal');
         const taxEl = document.getElementById('order-tax');
         const insuranceEl = document.getElementById('insurance-fee');
-        const subtotal = this.calculateSubtotal();
+        const nationalizationEl = document.getElementById('nationalization-amount');
+        const exchangeRateEl = document.getElementById('order-exchange-rate');
+
+        let subtotal = this.calculateSubtotal();
+        let total = this.calculateTotal();
+
+        if (this.lastPurchase) {
+            subtotal = this.lastPurchase.items.reduce((s, it) => s + it.price * it.quantity, 0);
+            total = this.lastPurchase.total;
+        }
+
         const tax = subtotal * this.config.taxRate;
-        const total = this.calculateTotal();
 
         if (subtotalEl) subtotalEl.textContent = `$${subtotal.toFixed(2)}`;
         if (taxEl) taxEl.textContent = `$${tax.toFixed(2)}`;
         if (this.orderTotal) this.orderTotal.textContent = `$${total.toFixed(2)}`;
         if (insuranceEl) insuranceEl.textContent = `$${this.state.selectedInsurance.price.toFixed(2)}`;
+        if (nationalizationEl) nationalizationEl.textContent = `${this.calculateNationalizationFee(total).toFixed(2)} Bs`;
+        if (exchangeRateEl) exchangeRateEl.textContent = `1 USD = ${this.config.exchangeRate.toFixed(2)} Bs`;
         
         // Update delivery dates
         this.updateDeliveryDates();


### PR DESCRIPTION
## Summary
- fix success page totals after cart is cleared
- show pending nationalization payment amount
- display exchange rate used for the transaction

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686041f14a248324a1ba6b00b30be483