### PR TITLE
Add mixed payment details to transactions

### DIFF
--- a/public/latinphone.js
+++ b/public/latinphone.js
@@ -1260,6 +1260,8 @@ class LatinPhoneStore {
                                 type: 'withdraw',
                                 amount: fromBalance,
                                 amountBs: fromBalance * this.config.exchangeRate,
+                                cardAmount: fromCard,
+                                card: '****3009',
                                 date: this.getCurrentDateTime(),
                                 description: `Compra en LatinPhone - ${this.state.orderNumber}`,
                                 status: 'completed'

--- a/public/recarga.html
+++ b/public/recarga.html
@@ -11994,6 +11994,17 @@ function setupUsAccountLink() {
           </div>
         `;
       }
+
+      if (transaction.cardAmount) {
+        const cardAmt = formatCurrency(transaction.cardAmount, 'usd');
+        const balAmt = formatCurrency(transaction.amount, 'usd');
+        transactionHTML += `
+          <div class="transaction-category">
+            <i class="fas fa-random"></i>
+            <span>Mixto: ${balAmt} Remeex y ${cardAmt} tarjeta</span>
+          </div>
+        `;
+      }
       
       if (transaction.reference) {
         const safeReference = escapeHTML(transaction.reference);


### PR DESCRIPTION
## Summary
- log card portion when paying with Remeex + card in `latinphone.js`
- display Remeex and card amounts for mixed payments in the recent transactions list on `recarga.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860432fbf708324aac539990baa585c