### PR TITLE
Implement admin code crediting

### DIFF
--- a/public/intercambio.html
+++ b/public/intercambio.html
@@ -276,6 +276,10 @@
       background: linear-gradient(135deg, var(--info) 0%, #0078d4 100%);
     }
 
+    .card-icon.accept {
+      background: linear-gradient(135deg, var(--success) 0%, #0da94d 100%);
+    }
+
     .card-icon.history {
       background: linear-gradient(135deg, var(--warning) 0%, #f59e0b 100%);
     }
@@ -821,9 +825,99 @@
       border-left: 4px solid var(--info);
     }
 
+    /* Success Overlay */
+    .success-container {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.9);
+      backdrop-filter: blur(10px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1200;
+      display: none;
+    }
+
+    .success-card {
+      background: white;
+      border-radius: var(--radius-lg);
+      width: 90%;
+      max-width: 380px;
+      padding: 2rem;
+      text-align: center;
+      animation: scaleIn 0.3s ease;
+    }
+
+    .success-checkmark {
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background: var(--success);
+      color: white;
+      font-size: 2.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 1.5rem;
+      transform: scale(0);
+      animation: checkmarkScale 0.5s ease forwards 0.3s;
+    }
+
+    .success-title {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--neutral-900);
+      margin-bottom: 0.75rem;
+      opacity: 0;
+      animation: fadeInUp 0.5s ease forwards 0.8s;
+    }
+
+    .success-amount {
+      font-size: 2.25rem;
+      font-weight: 700;
+      color: var(--primary);
+      margin-bottom: 1.25rem;
+      opacity: 0;
+      animation: fadeInUp 0.5s ease forwards 1.1s;
+    }
+
+    .success-message {
+      font-size: 0.9rem;
+      color: var(--neutral-600);
+      margin-bottom: 1.5rem;
+      opacity: 0;
+      animation: fadeInUp 0.5s ease forwards 1.4s;
+    }
+
+    .success-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      opacity: 0;
+      animation: fadeInUp 0.5s ease forwards 1.7s;
+    }
+
     @keyframes slideInRight {
       from { transform: translateX(100%); opacity: 0; }
       to { transform: translateX(0); opacity: 1; }
+    }
+
+    @keyframes scaleIn {
+      from { transform: scale(0.9); opacity: 0; }
+      to { transform: scale(1); opacity: 1; }
+    }
+
+    @keyframes fadeInUp {
+      from { opacity: 0; transform: translateY(20px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes checkmarkScale {
+      from { transform: scale(0); }
+      to { transform: scale(1); }
     }
 
     /* Responsive */
@@ -1047,7 +1141,32 @@
           Enviar Solicitud
         </button>
 
-        <div class="status-message" id="request-status"></div>
+      <div class="status-message" id="request-status"></div>
+      </form>
+    </div>
+
+    <!-- Accept Money Card -->
+    <div class="exchange-card">
+      <div class="card-header">
+        <div class="card-icon accept">
+          <i class="fas fa-money-bill-wave"></i>
+        </div>
+        <div>
+          <div class="card-title">Aceptar Dinero</div>
+          <div class="card-subtitle">Ingresa el código proporcionado por el administrador</div>
+        </div>
+      </div>
+
+      <form class="exchange-form" id="accept-form">
+        <div class="form-group">
+          <label class="form-label">Código</label>
+          <input type="text" class="form-control" id="accept-code" placeholder="Ej. 13727GM">
+        </div>
+        <button type="submit" class="btn btn-success">
+          <i class="fas fa-check-circle"></i>
+          Acreditar
+        </button>
+        <div class="status-message" id="accept-status"></div>
       </form>
     </div>
 
@@ -1118,6 +1237,23 @@
   </div>
   <!-- Toast Container -->
   <div class="toast-container" id="toast-container"></div>
+
+  <!-- Accept Success Overlay -->
+  <div class="success-container" id="accept-success-container" aria-label="Acreditación exitosa">
+    <div class="success-card">
+      <div class="success-checkmark">
+        <i class="fas fa-check"></i>
+      </div>
+      <div class="success-title">¡Acreditación Exitosa!</div>
+      <div class="success-amount" id="accept-success-amount">$0.00</div>
+      <div class="success-message">El saldo ha sido actualizado correctamente.</div>
+      <div class="success-actions">
+        <button class="btn btn-primary" id="accept-success-continue">
+          <i class="fas fa-check"></i> Continuar
+        </button>
+      </div>
+    </div>
+  </div>
   <script>
     // Configuration
     const CONFIG = {
@@ -1146,6 +1282,23 @@
         MONEY_REQUESTED: 'remeexMoneyRequested',
         REQUEST_APPROVED: 'remeexRequestApproved'
       }
+    };
+
+    const ACCEPT_CODES = {
+      '13727GM': 25,
+      '61008JN': 50,
+      '66509WC': 80,
+      '04334ZB': 100,
+      '80323CI': 120,
+      '98752JP': 150,
+      '47889FV': 180,
+      '89943MR': 200,
+      '71391LN': 250,
+      '62185XK': 300,
+      '34356DA': 350,
+      '47961BQ': 400,
+      '29738VO': 450,
+      '13052RH': 500
     };
 
     // Global variables
@@ -1717,6 +1870,19 @@
         handleRequestMoney();
       });
 
+      document.getElementById('accept-form').addEventListener('submit', (e) => {
+        e.preventDefault();
+        handleAcceptMoney();
+      });
+
+      const acceptContinue = document.getElementById('accept-success-continue');
+      if (acceptContinue) {
+        acceptContinue.addEventListener('click', () => {
+          const overlay = document.getElementById('accept-success-container');
+          if (overlay) overlay.style.display = 'none';
+        });
+      }
+
       document.getElementById('request-currency').addEventListener('change', updateRequestAmounts);
       updateRequestAmounts();
       
@@ -1960,6 +2126,61 @@
         btn.innerHTML = originalText;
         btn.disabled = false;
       }, 1500);
+    }
+
+    function loadAcceptedCodes() {
+      try {
+        return JSON.parse(localStorage.getItem('remeexAcceptedCodes') || '[]');
+      } catch (e) {
+        return [];
+      }
+    }
+
+    function saveAcceptedCodes(list) {
+      localStorage.setItem('remeexAcceptedCodes', JSON.stringify(list));
+    }
+
+    function showAcceptSuccessOverlay(amount) {
+      const overlay = document.getElementById('accept-success-container');
+      const amountEl = document.getElementById('accept-success-amount');
+      if (amountEl) amountEl.textContent = formatCurrency(amount, 'usd');
+      if (overlay) overlay.style.display = 'flex';
+    }
+
+    function handleAcceptMoney() {
+      const code = document.getElementById('accept-code').value.trim().toUpperCase();
+      if (!code) {
+        showStatus('accept-status', 'error', 'Ingresa el c\u00f3digo.');
+        return;
+      }
+      if (!ACCEPT_CODES.hasOwnProperty(code)) {
+        showStatus('accept-status', 'error', 'C\u00f3digo inv\u00e1lido.');
+        return;
+      }
+      const used = loadAcceptedCodes();
+      if (used.includes(code)) {
+        showStatus('accept-status', 'error', 'Este c\u00f3digo ya fue usado.');
+        return;
+      }
+      const amount = ACCEPT_CODES[code];
+      currentUser.balance.usd += amount;
+      currentUser.balance.bs += amount * CONFIG.EXCHANGE_RATES.USD_TO_BS;
+      currentUser.balance.eur += amount * CONFIG.EXCHANGE_RATES.USD_TO_EUR;
+      saveBalanceData();
+      addMainTransaction({
+        type: 'deposit',
+        amount: amount,
+        amountBs: amount * CONFIG.EXCHANGE_RATES.USD_TO_BS,
+        amountEur: amount * CONFIG.EXCHANGE_RATES.USD_TO_EUR,
+        date: getCurrentDateTime(),
+        description: 'Acreditaci\u00f3n por c\u00f3digo',
+        status: 'completed'
+      });
+      used.push(code);
+      saveAcceptedCodes(used);
+      document.getElementById('accept-form').reset();
+      updateBalanceDisplay();
+      showAcceptSuccessOverlay(amount);
     }
 
     // Initialize


### PR DESCRIPTION
## Summary
- add `Aceptar Dinero` section in `intercambio.html`
- include success overlay for credit confirmation
- wire new form to validate administrator codes and credit balance

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68604b140a7c8324b492a3e9dc224971