### PR TITLE
Fix 'Mi Estatus' link

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -10233,7 +10233,7 @@ function stopVerificationProgress() {
 
       if (statusBtn) {
         statusBtn.addEventListener('click', function() {
-          window.location.href = 'estatus.hml';
+          window.location.href = 'estatus.html';
           resetInactivityTimer();
         });
       }


### PR DESCRIPTION
## Summary
- correct the `Mi Estatus` button on `recarga.html` so it links to `estatus.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686051d3db48832488603a8a7e6669d3