### PR TITLE
Fix forum and settings links

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -4897,7 +4897,7 @@
   <!-- App Header (only visible after login) -->
   <header class="app-header" id="app-header" style="display: none;">
     <div class="header-brand">
-      <a href="index">
+      <a href="https://home.remeexvisa.com">
         <img src="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhnBzNdjl6bNp-nIdaiHVENczJhwlJNA7ocsyiOObMmzbu8at0dY5yGcZ9cLxLF39qI6gwNfqBxlkTDC0txVULEwQVwGkeEzN0Jq9MRTRagA48mh18UqTlR4WhsXOLAEZugUyhqJHB19xJgnkpe-S5VOWFgzpKFwctv3XP9XhH41vNTvq0ZS-nik58Qhr-O/s320/remeex.png" alt="REMEEX">
       </a>
     </div>
@@ -9593,7 +9593,7 @@ function stopVerificationProgress() {
       if (activationNavBtn) {
         activationNavBtn.addEventListener('click', function() {
           // Redirigir a activacion
-          window.location.href = '';
+          window.location.href = 'activacion.html';
 
           // Reset inactivity timer
           resetInactivityTimer();
@@ -10583,10 +10583,10 @@ function stopVerificationProgress() {
       if (email) email.addEventListener('click', () => { window.location.href = 'mailto:contactcenter@visa.com'; closeOverlay(); });
 
       const userChat = document.getElementById('help-userchat');
-      if (userChat) userChat.addEventListener('click', () => { openPage(''); closeOverlay(); });
+      if (userChat) userChat.addEventListener('click', () => { openPage('fororemeex.html'); closeOverlay(); });
 
       const commentsBtn = document.getElementById('help-comments');
-      if (commentsBtn) commentsBtn.addEventListener('click', () => { openPage(''); closeOverlay(); });
+      if (commentsBtn) commentsBtn.addEventListener('click', () => { openPage('opinionesremeex.html'); closeOverlay(); });
 
       const tutorials = document.getElementById('help-tutorials');
       if (tutorials) tutorials.classList.add('disabled');
@@ -10599,7 +10599,7 @@ function stopVerificationProgress() {
     const badge = document.getElementById('online-users-link');
     if (badge) {
       badge.addEventListener('click', function() {
-        window.location.href = '';
+        window.location.href = 'fororemeex.html';
       });
     }
   }


### PR DESCRIPTION
## Summary
- fix main logo link to go to external home site
- connect online users LED to forum
- update help options to open forum and opinions pages
- wire activation button to `activacion.html`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860565f80d48324b8afefc15888cc09