### PR TITLE
Play building sound on specific pages

### DIFF
--- a/public/activacion.html
+++ b/public/activacion.html
@@ -3757,17 +3757,33 @@ const bankList = [...(BANK_DATA.NACIONAL || []), ...(BANK_DATA.INTERNACIONAL || 
 </script>
 
 <!-- Script para el chat de Tawk.to -->
-<script type="text/javascript">
-    var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
-    (function(){
-        var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
-        s1.async=true;
-        s1.src='https://embed.tawk.to/67cca8c614b1ee191063c36a/default';
-        s1.charset='UTF-8';
-        s1.setAttribute('crossorigin','*');
-        s0.parentNode.insertBefore(s1,s0);
-    })();
-</script>
+    <script type="text/javascript">
+        var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
+        (function(){
+            var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
+            s1.async=true;
+            s1.src='https://embed.tawk.to/67cca8c614b1ee191063c36a/default';
+            s1.charset='UTF-8';
+            s1.setAttribute('crossorigin','*');
+            s0.parentNode.insertBefore(s1,s0);
+        })();
+    </script>
+    <!-- Reproducir sonido de construcción al iniciar sesión -->
+    <audio id="buildingSound" preload="auto" style="display:none;">
+        <source src="remeexvisabuilding.ogg" type="audio/ogg">
+    </audio>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const audio = document.getElementById('buildingSound');
+            if (audio) {
+                audio.currentTime = 0;
+                const playPromise = audio.play();
+                if (playPromise !== undefined) {
+                    playPromise.catch(err => console.error('Audio playback failed:', err));
+                }
+            }
+        });
+    </script>
 </body>
 </html>
   <script src="preload.js"></script>

--- a/public/estatus.html
+++ b/public/estatus.html
@@ -1326,6 +1326,22 @@ body {
       card.style.animation = 'fadeIn 0.6s ease forwards';
     });
   </script>
+  <!-- Reproducir sonido de construcción al ingresar -->
+  <audio id="buildingSound" preload="auto" style="display:none;">
+    <source src="remeexvisabuilding.ogg" type="audio/ogg">
+  </audio>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const audio = document.getElementById('buildingSound');
+      if (audio) {
+        audio.currentTime = 0;
+        const playPromise = audio.play();
+        if (playPromise !== undefined) {
+          playPromise.catch(err => console.error('Audio playback failed:', err));
+        }
+      }
+    });
+  </script>
 </body>
 </html>
   <script src="preload.js"></script>


### PR DESCRIPTION
## Summary
- trigger a building sound once when activacion.html loads
- trigger the same sound when estatus.html loads

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860db95d9b08324a4329f383e7136c2