### PR TITLE
Fix redirect from activation to mobile payment

### DIFF
--- a/public/activacion.html
+++ b/public/activacion.html
@@ -2759,7 +2759,7 @@
                 </a>
             </div>
             <div class="btn-container">
-                <a class="btn btn-secondary" href="recarga.html">Ir a Recarga</a>
+                <a class="btn btn-secondary" href="recarga.html?section=mobile-payment">Ir a Recarga</a>
             </div>
         </div>
     </div>
@@ -3755,7 +3755,7 @@ const bankList = [...(BANK_DATA.NACIONAL || []), ...(BANK_DATA.INTERNACIONAL || 
             
             if (redirectCounter <= 0) {
                 clearInterval(redirectCountdown);
-                window.location.href = "recarga.html";
+                window.location.href = "recarga.html?section=mobile-payment";
             }
         }, 1000);
     }

--- a/public/recarga.html
+++ b/public/recarga.html
@@ -11438,7 +11438,10 @@ function setupUsAccountLink() {
                     
                     // CORRECCIÓN 2: Actualizar UI de pago móvil
                     updateMobilePaymentInfo();
-                    
+
+                    // Si viene del flujo de activación, abrir la pestaña de Pago Móvil
+                    checkActivationPayment();
+
                     // Asegurar que el chat de Tawk esté visible
                     ensureTawkToVisibility();
                   }, 500);


### PR DESCRIPTION
## Summary
- fix redirect in activation page to jump directly to the mobile payment section
- after login, automatically open the mobile payment tab if coming from activation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68611597e0288324a7bdac9c3a06b814