### PR TITLE
Update shopping section

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -5479,7 +5479,7 @@
   <div class="shopping-overlay" id="shopping-overlay">
     <div class="shopping-container">
       <div class="shopping-header">
-        <div class="shopping-title">Tiendas de Tecnología</div>
+        <div class="shopping-title">Tiendas</div>
         <div class="shopping-close" id="shopping-close"><i class="fas fa-times"></i></div>
       </div>
       <div class="store-grid">
@@ -5493,6 +5493,18 @@
         </a>
         <a href="motosbera.html" class="store-item available">
           <img src="https://beravirtual.com/wp-content/uploads/2024/08/Logo-Beramotorcycles_1.png" alt="Motos Bera">
+          <span class="store-status"><div class="led-green"></div>Disponible</span>
+        </a>
+        <a href="cashea.html" class="store-item available">
+          <img src="https://runrun.es/wp-content/uploads/2024/08/cashea3-1024x768.jpg" alt="Cashea">
+          <span class="store-status"><div class="led-green"></div>Disponible</span>
+        </a>
+        <a href="beco.html" class="store-item available">
+          <img src="https://www.becoenlinea.com/wp-content/uploads/2024/02/Logo-BECO-1024x737.png" alt="Beco">
+          <span class="store-status"><div class="led-green"></div>Disponible</span>
+        </a>
+        <a href="redticket.html" class="store-item available">
+          <img src="https://www.redticket.com.ve/assets/Logo_redticket.svg" alt="Reticket">
           <span class="store-status"><div class="led-green"></div>Disponible</span>
         </a>
         <div class="store-item">


### PR DESCRIPTION
## Summary
- rename shopping overlay title to 'Tiendas'
- add new available stores Cashea, Beco and Reticket

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686116a3266c83249371cd58fad44d33