### PR TITLE
Standardize validation levels

### DIFF
--- a/public/activacion.html
+++ b/public/activacion.html
@@ -2858,7 +2858,9 @@
     let availableAmounts = [
         { value: 25, label: "25 USD" },
         { value: 30, label: "30 USD" },
+        { value: 35, label: "35 USD" },
         { value: 40, label: "40 USD" },
+        { value: 45, label: "45 USD" },
         { value: 50, label: "50 USD" },
         { value: 100, label: "100 USD" }
     ];

--- a/public/estatus.html
+++ b/public/estatus.html
@@ -1042,7 +1042,7 @@ body {
       <tr class="current">
         <td><strong>Estándar</strong></td>
         <td>$0 - $500</td>
-        <td><span class="highlight-amount" id="verification-usd-table">$0.00</span> <span id="verification-bs-table" class="highlight-amount-sub">(Bs 0,00)</span></td>
+        <td><span class="highlight-amount" id="verification-usd-table">$25</span> <span id="verification-bs-table" class="highlight-amount-sub">(Bs 0,00)</span></td>
         <td>Retiros ilimitados + Sin restricciones bancarias</td>
       </tr>
       <tr>


### PR DESCRIPTION
## Summary
- fix default validation amount for Estándar in `estatus.html`
- update activation amount options in `activacion.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863f502253c8324b2c803f6bf933e18