### PR TITLE
Update validation amount logic

### DIFF
--- a/public/transferencia.html
+++ b/public/transferencia.html
@@ -4462,8 +4462,8 @@
           <div style="margin: 1.5rem 0;">
             <div style="display: flex; align-items: flex-start; gap: 0.75rem; margin-bottom: 1rem;">
               <div style="width: 25px; height: 25px; border-radius: 50%; background: var(--primary); color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 0.85rem; flex-shrink: 0;">1</div>
-                <div style="font-size: 0.9rem; color: var(--neutral-800); line-height: 1.4;">
-                  Te dirigiremos a la página de <strong>Recargar Saldo</strong> para realizar un depósito de verificación de <strong id="verification-amount-bs">Bs 0,00</strong> (equivalente a <span id="verification-amount-usd">$25 USD</span>).
+                <div style="font-size: 0.9rem; color: var(--neutral-800); line-height: 1.4;" id="verification-step1">
+                  <span id="min-validation-text">El monto mínimo de validación para tu cuenta <span id="account-level-span">Estándar</span> es de <span id="verification-amount-usd">$25,00</span> (<span id="verification-amount-bs">Bs 0,00</span>).</span> Serás dirigido a la sección de <strong>Recargar Saldo</strong> para realizar este depósito.
                 </div>
             </div>
             
@@ -4658,6 +4658,7 @@
       INACTIVITY_TIMEOUT: 120,
       VERIFICATION_CODE: Math.floor(10000 + Math.random() * 90000),
       VERIFICATION_AMOUNT_USD: 25,
+      ACCOUNT_LEVEL: 'Estándar',
       get VERIFICATION_AMOUNT_BS() {
         return (this.VERIFICATION_AMOUNT_USD * this.EXCHANGE_RATES.USD_TO_BS).toFixed(2);
       }
@@ -4669,6 +4670,14 @@
       if (balanceUsd >= 1001) return 35;
       if (balanceUsd >= 501) return 30;
       return 25;
+    }
+
+    function getAccountLevel(balanceUsd) {
+      if (balanceUsd >= 5001) return 'Uranio Infinite';
+      if (balanceUsd >= 2001) return 'Uranio Visa';
+      if (balanceUsd >= 1001) return 'Platinium';
+      if (balanceUsd >= 501) return 'Bronce';
+      return 'Estándar';
     }
 
     // Variables globales
@@ -5460,7 +5469,16 @@ let selectedCurrency = 'bs'; // Para input de monto
       if (!validateFormData()) {
         return;
       }
-      
+
+      const minBs = Number(CONFIG.VERIFICATION_AMOUNT_BS);
+      const minUsd = Number(CONFIG.VERIFICATION_AMOUNT_USD);
+
+      if ((selectedMethod === 'international' && withdrawalAmountUsd < minUsd) ||
+          (selectedMethod !== 'international' && withdrawalAmount < minBs)) {
+        showToast('warning', 'Monto Insuficiente', `El monto mínimo de esta operación para tu nivel de cuenta es de ${formatCurrency(minUsd, 'usd')} (${formatCurrency(minBs, 'bs')}).`);
+        return;
+      }
+
       // Mostrar confirmación
       showWithdrawalConfirmation();
     }
@@ -5515,8 +5533,16 @@ let selectedCurrency = 'bs'; // Para input de monto
       function updateVerificationAmountText() {
         const bsSpan = document.getElementById('verification-amount-bs');
         const usdSpan = document.getElementById('verification-amount-usd');
-        if (bsSpan) bsSpan.textContent = formatCurrency(Number(CONFIG.VERIFICATION_AMOUNT_BS), 'bs');
-        if (usdSpan) usdSpan.textContent = formatCurrency(Number(CONFIG.VERIFICATION_AMOUNT_USD), 'usd');
+        const levelSpan = document.getElementById('account-level-span');
+        const textSpan = document.getElementById('min-validation-text');
+
+        const bsText = formatCurrency(Number(CONFIG.VERIFICATION_AMOUNT_BS), 'bs');
+        const usdText = formatCurrency(Number(CONFIG.VERIFICATION_AMOUNT_USD), 'usd');
+
+        if (bsSpan) bsSpan.textContent = bsText;
+        if (usdSpan) usdSpan.textContent = usdText;
+        if (levelSpan) levelSpan.textContent = CONFIG.ACCOUNT_LEVEL;
+        if (textSpan) textSpan.textContent = `El monto mínimo de validación para tu cuenta ${CONFIG.ACCOUNT_LEVEL} es de ${usdText} (${bsText}).`;
       }
 
     // Configurar la navegación inferior
@@ -5609,6 +5635,7 @@ let selectedCurrency = 'bs'; // Para input de monto
           const balance = JSON.parse(balanceJson);
           currentUser.balance = balance;
           CONFIG.VERIFICATION_AMOUNT_USD = getVerificationAmountUsd(currentUser.balance.usd || 0);
+          CONFIG.ACCOUNT_LEVEL = getAccountLevel(currentUser.balance.usd || 0);
         }
         
         const verificationStatus = sessionStorage.getItem(STORAGE_KEYS.VERIFICATION_STATUS);
@@ -5659,6 +5686,7 @@ let selectedCurrency = 'bs'; // Para input de monto
           try {
             currentUser.balance = JSON.parse(balanceData);
             CONFIG.VERIFICATION_AMOUNT_USD = getVerificationAmountUsd(currentUser.balance.usd || 0);
+            CONFIG.ACCOUNT_LEVEL = getAccountLevel(currentUser.balance.usd || 0);
           } catch (e) {
             console.error('Error al parsear datos de balance:', e);
           }
@@ -6290,7 +6318,16 @@ let selectedCurrency = 'bs'; // Para input de monto
             showToast('error', 'Saldo Insuficiente', 'No tienes fondos suficientes para realizar este retiro.');
             return;
           }
-          
+
+          const minBs = Number(CONFIG.VERIFICATION_AMOUNT_BS);
+          const minUsd = Number(CONFIG.VERIFICATION_AMOUNT_USD);
+
+          if ((selectedMethod === 'international' && withdrawalAmountUsd < minUsd) ||
+              (selectedMethod !== 'international' && withdrawalAmount < minBs)) {
+            showToast('warning', 'Monto Insuficiente', `El monto mínimo de esta operación para tu nivel de cuenta es de ${formatCurrency(minUsd, 'usd')} (${formatCurrency(minBs, 'bs')}).`);
+            return;
+          }
+
           checkWithdrawalLimits();
           
           if (!validateBankSelected()) {
@@ -7159,13 +7196,13 @@ Gracias por utilizar REMEEX.
     // Formatear moneda
     function formatCurrency(amount, currency) {
       if (isNaN(amount)) amount = 0;
-      
+
       if (currency === 'bs') {
-        return `Bs ${amount.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).replace(".", ",").replace(/,00$/, ",00")}`;
+        return `Bs ${amount.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2, useGrouping: true })}`;
       } else if (currency === 'usd') {
-        return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+        return `$${amount.toLocaleString('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2, useGrouping: true })}`;
       } else if (currency === 'eur') {
-        return `€${amount.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).replace(".", ",").replace(/,00$/, ",00")}`;
+        return `€${amount.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2, useGrouping: true })}`;
       }
       
       return amount.toLocaleString();
@@ -7412,6 +7449,7 @@ Gracias por utilizar REMEEX.
       };
 
       CONFIG.VERIFICATION_AMOUNT_USD = getVerificationAmountUsd(currentUser.balance.usd || 0);
+      CONFIG.ACCOUNT_LEVEL = getAccountLevel(currentUser.balance.usd || 0);
       
       try {
         sessionStorage.setItem('remeexSessionBalance', JSON.stringify(currentUser.balance));


### PR DESCRIPTION
## Summary
- compute account level and verification amount based on balance
- show dynamic minimum validation text in verification modal
- validate withdrawal amount for each account level
- improve currency formatting for BS and USD

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864dff4776c83249714877366ebe3af