### PR TITLE
Add account tier overlay button

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -5329,6 +5329,7 @@
                   <button class="btn btn-outline btn-small" id="view-status">Mi Estatus</button>
                   <button class="btn btn-outline btn-small" id="bank-support">Soporte</button>
                   <button class="btn btn-outline btn-small" id="play-instructions"><i class="fas fa-play"></i> Escuchar</button>
+                  <button class="btn btn-outline btn-small" id="view-account-level">Ver mi nivel de cuenta</button>
                 </div>
                 <div id="bank-validation-progress-container" class="verification-progress-container" style="display: none;">
                   <div id="bank-validation-progress-bar" class="verification-progress-bar"></div>
@@ -8468,16 +8469,19 @@ function stopVerificationProgress() {
     }
 
     function setupAccountTierOverlay() {
-      const btn = document.getElementById('account-tier-btn');
       const overlay = document.getElementById('account-tier-overlay');
       const close = document.getElementById('account-tier-close');
-      if (btn) {
+      const triggers = [
+        document.getElementById('account-tier-btn'),
+        document.getElementById('view-account-level')
+      ].filter(Boolean);
+      triggers.forEach(btn => {
         btn.addEventListener('click', () => {
           highlightCurrentTierRow();
           populateValidationInfo();
           if (overlay) overlay.style.display = 'flex';
         });
-      }
+      });
       if (close) {
         close.addEventListener('click', () => {
           if (overlay) overlay.style.display = 'none';


### PR DESCRIPTION
## Summary
- show account level info from the pending verification card
- support multiple buttons for opening the account tier overlay

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864e9e908308324b7a80628af5b098e