### PR TITLE
Improve main balance action buttons

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -484,28 +484,29 @@
     
     .balance-actions {
       display: flex;
-      gap: 0.75rem;
-      margin-top: 0.75rem;
+      flex-direction: column;
+      gap: 1rem;
+      margin-top: 1rem;
     }
 
     .balance-actions .action-group {
-      flex: 1;
+      flex: 1 1 auto;
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.75rem;
     }
-    
+
     .balance-btn {
       flex: 1;
       border: none;
       border-radius: var(--radius-full);
-      height: 50px;
-      padding: 0 1.25rem;
+      height: 60px;
+      padding: 0 1.5rem;
       display: flex;
       align-items: center;
       justify-content: center;
       font-weight: 600;
-      font-size: 0.9rem;
+      font-size: 1rem;
       background: var(--primary);
       color: #fff;
       cursor: pointer;
@@ -532,6 +533,12 @@
       opacity: 0.6;
       cursor: not-allowed;
       transform: none;
+    }
+
+    @media (min-width: 500px) {
+      .balance-actions {
+        flex-direction: row;
+      }
     }
     
     /* Pending transactions badge */
@@ -4851,8 +4858,8 @@
       }
       
       .balance-btn {
-        height: 50px;
-        font-size: 0.95rem;
+        height: 64px;
+        font-size: 1.05rem;
       }
 
       .service-grid,


### PR DESCRIPTION
## Summary
- enlarge buttons in main balance card
- add spacing for better tap targets

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686508b576d48324a9d4cfe55552c957