### PR TITLE
Update tier progress overlay to refresh verification amounts

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -12840,6 +12840,8 @@ function checkTierProgressOverlay() {
   if (!stored) {
     localStorage.setItem('remeexAccountTier', current.name);
     currentTier = current.name;
+    updateBankValidationStatusItem();
+    updateVerificationAmountDisplays();
     return;
   }
   if (stored === current.name) {
@@ -12884,6 +12886,8 @@ function checkTierProgressOverlay() {
   }
   currentTier = current.name;
   localStorage.setItem('remeexAccountTier', current.name);
+  updateBankValidationStatusItem();
+  updateVerificationAmountDisplays();
 }
 
     // Construir mensaje de soporte para WhatsApp


### PR DESCRIPTION
## Summary
- update `checkTierProgressOverlay` to refresh card amounts when the user's tier changes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686515450b208324a3226023b655ded8