### PR TITLE
Redesign balance action buttons in recarga.html

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -483,40 +483,40 @@
     }
     
     .balance-actions {
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      grid-auto-rows: minmax(56px, auto);
       gap: 1rem;
       margin-top: 1rem;
     }
 
     .balance-actions .action-group {
-      flex: 1 1 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
+      display: contents;
     }
 
     .balance-btn {
-      flex: 1;
-      border: none;
-      border-radius: var(--radius-full);
-      height: 60px;
-      padding: 0 1.5rem;
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      border-radius: var(--radius-xl);
+      padding: 0.75rem 1rem;
+      height: 100%;
       display: flex;
       align-items: center;
       justify-content: center;
       font-weight: 600;
       font-size: 1rem;
-      background: var(--primary);
+      background: rgba(255, 255, 255, 0.1);
       color: #fff;
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
       cursor: pointer;
       transition: var(--transition-base);
       box-shadow: var(--shadow-md);
       white-space: nowrap;
     }
-    
+
     .balance-btn:hover {
-      background: var(--primary-light);
+      background: rgba(255, 255, 255, 0.2);
+      box-shadow: var(--shadow-lg);
       transform: translateY(-2px);
     }
     
@@ -535,9 +535,29 @@
       transform: none;
     }
 
+    #send-btn {
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    #recharge-btn {
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    #intercambioBtn {
+      grid-column: 1;
+      grid-row: 2;
+    }
+
+    #zelleBtn {
+      grid-column: 2;
+      grid-row: 2;
+    }
+
     @media (min-width: 500px) {
       .balance-actions {
-        flex-direction: row;
+        grid-template-columns: repeat(2, 1fr);
       }
     }
     
@@ -4851,7 +4871,7 @@
       }
     }
     
-    @media (min-width: 768px) {
+@media (min-width: 768px) {
       .app-container {
         max-width: 100%;
       }
@@ -4868,8 +4888,10 @@
         font-size: 2.36rem;
       }
       
+      .balance-actions {
+        grid-auto-rows: 64px;
+      }
       .balance-btn {
-        height: 64px;
         font-size: 1.05rem;
       }
 
@@ -5230,14 +5252,14 @@
             </div>
             
             <div class="balance-actions">
-              <div class="action-group" id="recharge-group">
-                <button class="balance-btn" id="recharge-btn">
-                  <i class="fas fa-plus-circle"></i> Recargar Saldo
-                </button>
-              </div>
               <div class="action-group" id="withdraw-group">
                 <button class="balance-btn" id="send-btn">
                   <i class="fas fa-upload"></i> Retirar Dinero
+                </button>
+              </div>
+              <div class="action-group" id="recharge-group">
+                <button class="balance-btn" id="recharge-btn">
+                  <i class="fas fa-plus-circle"></i> Recargar Saldo
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- reorder withdraw and recharge buttons
- style balance actions with CSS grid
- modernize balance button appearance
- assign grid positions for Intercambio and Zelle

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865193aba608324a36ea18c5ca3a506