### PR TITLE
Adjust balance buttons order and size

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -485,7 +485,7 @@
     .balance-actions {
       display: grid;
       grid-template-columns: repeat(2, 1fr);
-      grid-auto-rows: minmax(56px, auto);
+      grid-auto-rows: minmax(50px, auto);
       gap: 1rem;
       margin-top: 1rem;
     }
@@ -497,13 +497,13 @@
     .balance-btn {
       border: 1px solid rgba(255, 255, 255, 0.3);
       border-radius: var(--radius-xl);
-      padding: 0.675rem 0.9rem;
+      padding: 0.61rem 0.81rem;
       height: 100%;
       display: flex;
       align-items: center;
       justify-content: center;
       font-weight: 600;
-      font-size: 0.9rem;
+      font-size: 0.81rem;
       background: rgba(255, 255, 255, 0.1);
       color: #fff;
       backdrop-filter: blur(8px);
@@ -526,7 +526,7 @@
 
     .balance-btn i {
       margin-right: 6px;
-      font-size: 0.9rem;
+      font-size: 0.81rem;
     }
 
     .balance-btn:disabled {
@@ -536,12 +536,12 @@
     }
 
     #send-btn {
-      grid-column: 1;
+      grid-column: 2;
       grid-row: 1;
     }
 
     #recharge-btn {
-      grid-column: 2;
+      grid-column: 1;
       grid-row: 1;
     }
 
@@ -4894,10 +4894,10 @@
       }
       
       .balance-actions {
-        grid-auto-rows: 64px;
+        grid-auto-rows: 58px;
       }
       .balance-btn {
-        font-size: 0.945rem;
+        font-size: 0.85rem;
       }
 
       .service-grid,


### PR DESCRIPTION
## Summary
- switch grid positioning of **Recargar Saldo** and **Retirar dinero** buttons so recharge appears first
- shrink main balance card buttons by 10%

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865a88519048324841585d88a8a9a0e