### PR TITLE
Fix spacing and sizing issues on dashboard buttons

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -512,6 +512,7 @@
       transition: var(--transition-base);
       box-shadow: var(--shadow-md);
       white-space: nowrap;
+      width: 100%;
     }
 
     .balance-btn:hover {
@@ -5357,7 +5358,7 @@
             <div class="balance-actions">
               <div class="action-group" id="withdraw-group">
                 <button class="balance-btn" id="send-btn">
-                  <i class="fas fa-upload"></i> Retirar Dinero a <span id="send-bank-name"></span>
+                  <i class="fas fa-upload"></i> Retirar Dinero a&nbsp;<span id="send-bank-name"></span>
                 </button>
               </div>
               <div class="action-group" id="recharge-group">


### PR DESCRIPTION
## Summary
- ensure action buttons stretch the width of their grid cell
- fix missing space in the withdraw button label

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865b45b9bcc832487d82f9cd680509d