### PR TITLE
Improve LatinPhone post-purchase features

### DIFF
--- a/public/latinphone.css
+++ b/public/latinphone.css
@@ -2524,9 +2524,62 @@ body {
     padding: var(--space-4);
 }
 
+.purchase-details-btn {
+    background: var(--primary-600);
+    color: white;
+    border: none;
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+}
+
+.purchase-details-btn:hover {
+    background: var(--primary-700);
+}
+
 .empty-purchases {
     color: var(--gray-600);
     text-align: center;
+}
+
+/* Purchase Details Overlay */
+.purchase-details-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(10px);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 3000;
+}
+
+.purchase-details-card {
+    background: white;
+    padding: var(--space-8);
+    border-radius: var(--radius-xl);
+    max-width: 420px;
+    width: 90%;
+    position: relative;
+}
+
+.purchase-details-close {
+    position: absolute;
+    top: var(--space-3);
+    right: var(--space-3);
+    background: none;
+    border: none;
+    font-size: var(--text-lg);
+    color: var(--gray-600);
+    cursor: pointer;
+}
+
+.purchase-details-card ul {
+    padding-left: var(--space-4);
+    margin-bottom: var(--space-4);
 }
 
 /* Loading Overlay */
@@ -3218,6 +3271,7 @@ body {
     .success-actions,
     .loading-overlay,
     .modal-overlay,
+    .purchase-details-overlay,
     .video-modal,
     .toast-container {
         display: none !important;

--- a/public/latinphone.html
+++ b/public/latinphone.html
@@ -971,6 +971,16 @@
         </div>
     </div>
 
+    <!-- Purchase Details Overlay -->
+    <div class="purchase-details-overlay" id="purchase-details-overlay">
+        <div class="purchase-details-card">
+            <button class="purchase-details-close" id="purchase-details-close">
+                <i class="fas fa-times"></i>
+            </button>
+            <div class="purchase-details" id="purchase-details"></div>
+        </div>
+    </div>
+
     <!-- Toast Container -->
     <div class="toast-container" id="toast-container">
         <!-- Toasts will be added dynamically -->


### PR DESCRIPTION
## Summary
- add purchase detail overlay to HTML
- style overlay and buttons
- implement purchase detail logic and shipping date generation
- allow viewing purchase details from purchase history

## Testing
- `npm run build`
- `node --check public/latinphone.js`
- `npm start` *(fails until running `npm install`, then server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6866b8c068508324adba52f717ef3bda