### PR TITLE
Add more users to intercambio

### DIFF
--- a/public/intercambio.html
+++ b/public/intercambio.html
@@ -1351,7 +1351,19 @@
       VALID_EMAILS: [
         'patrickdlavangart@gmail.com',
         'wilkermancito69x@gmail.com',
-        'yolandacamacho2021@hotmail.com'
+        'yolandacamacho2021@hotmail.com',
+        'winfreinerjose24@gmail.com',
+        'yonclei_camacho97@gmail.com',
+        'dilinger.nataniel05@gmail.com',
+        'wilanderson_rojas21@gmail.com',
+        'oskeiber.maicolber33@gmail.com',
+        'osnairo.eniliexis09@gmail.com',
+        'wilkler.anibal88@gmail.com',
+        'yorfranwil_ysnkr23@gmail.com',
+        'leikel_david17@gmail.com',
+        'yosneiskerherreraruiz10@gmail.com',
+        'yorbisyeifran.mc20@gmail.com',
+        'yorjanderali_12@gmail.com'
       ],
       VERIFICATION_CODES: {
         'patrickdlavangart@gmail.com': '656464D',
@@ -1369,6 +1381,54 @@
         },
         'yolandacamacho2021@hotmail.com': {
           name: 'Elizabeth Yolanda Camacho Perez',
+          country: 'Venezuela'
+        },
+        'winfreinerjose24@gmail.com': {
+          name: 'Winfreiner José Guaramato López',
+          country: 'Venezuela'
+        },
+        'yonclei_camacho97@gmail.com': {
+          name: 'Yoncleiverson Andrés Camacho Lopez',
+          country: 'Venezuela'
+        },
+        'dilinger.nataniel05@gmail.com': {
+          name: 'Dilinger Nataniel Camacho Carrillo',
+          country: 'Venezuela'
+        },
+        'wilanderson_rojas21@gmail.com': {
+          name: 'Wilanderson Aníbal Rojas Chumaceiro',
+          country: 'Venezuela'
+        },
+        'oskeiber.maicolber33@gmail.com': {
+          name: 'Oskeiber Maicolber Pérez González',
+          country: 'Venezuela'
+        },
+        'osnairo.eniliexis09@gmail.com': {
+          name: 'Osnairo Eniliexis Romero Rojas',
+          country: 'Venezuela'
+        },
+        'wilkler.anibal88@gmail.com': {
+          name: 'Wilkler Aníbal Herrera Ruiz',
+          country: 'Venezuela'
+        },
+        'yorfranwil_ysnkr23@gmail.com': {
+          name: 'Yorfranwil Yusneiker Guaramato Ruiz',
+          country: 'Venezuela'
+        },
+        'leikel_david17@gmail.com': {
+          name: 'Leikelson David Camacho Herrera',
+          country: 'Venezuela'
+        },
+        'yosneiskerherreraruiz10@gmail.com': {
+          name: 'Yosneisker Rafael Herrera Ruiz',
+          country: 'Venezuela'
+        },
+        'yorbisyeifran.mc20@gmail.com': {
+          name: 'Yorbis Yeifran Medina Collado',
+          country: 'Venezuela'
+        },
+        'yorjanderali_12@gmail.com': {
+          name: 'Yorjander Alí García Sánchez',
           country: 'Venezuela'
         }
       },


### PR DESCRIPTION
## Summary
- extend the list of valid emails in `intercambio.html`
- add corresponding user details for these new users

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68679e04a0b083248f5328a60240906a