### PR TITLE
Fix balance card button sizing

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -504,7 +504,9 @@
       align-items: center;
       justify-content: center;
       font-weight: 600;
-      font-size: 0.81rem;
+      font-size: clamp(0.72rem, 2.5vw, 0.85rem);
+      overflow: hidden;
+      text-overflow: ellipsis;
       background: rgba(255, 255, 255, 0.1);
       color: #fff;
       backdrop-filter: blur(8px);
@@ -4963,7 +4965,7 @@
         grid-auto-rows: 58px;
       }
       .balance-btn {
-        font-size: 0.85rem;
+        font-size: clamp(0.72rem, 2vw, 0.85rem);
       }
 
       .service-grid,


### PR DESCRIPTION
## Summary
- keep main balance action buttons uniformly sized
- shrink font if text gets too long

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68679f017c9083248470c439b3b43d1d