### PR TITLE
Fix button label on recarga page

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -5566,7 +5566,7 @@
                   <button class="btn btn-outline btn-small" id="start-recharge">Validar, realizar recarga</button>
                   <button class="btn btn-outline btn-small" id="view-status">Mi Estatus</button>
                   <button class="btn btn-outline btn-small" id="bank-support">Soporte</button>
-                  <button class="btn btn-outline btn-small" id="play-instructions"><i class="fas fa-play"></i> Escuchar</button>
+                  <button class="btn btn-outline btn-small" id="play-instructions"><i class="fas fa-play"></i> Escuchar instrucciones</button>
                   <button class="btn btn-outline btn-small" id="view-account-level">Ver mi nivel de cuenta</button>
                 </div>
                 <div id="bank-validation-progress-container" class="verification-progress-container" style="display: none;">


### PR DESCRIPTION
## Summary
- change the label of the "Escuchar" button to "Escuchar instrucciones" in `recarga.html`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68679feff9388324b6be0c8fc13f9a1d