### PR TITLE
Add profile photo upload feature

### DIFF
--- a/public/ajustes.html
+++ b/public/ajustes.html
@@ -559,6 +559,38 @@
       flex: 1;
     }
 
+    .profile-photo-container {
+      position: relative;
+      width: 96px;
+      height: 96px;
+      margin: 0 auto 1rem;
+    }
+
+    #profile-photo {
+      width: 100%;
+      height: 100%;
+      border-radius: var(--radius-full);
+      object-fit: cover;
+      background: var(--neutral-300);
+      display: block;
+    }
+
+    .profile-photo-edit {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: 28px;
+      height: 28px;
+      border-radius: var(--radius-full);
+      background: var(--primary);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      font-size: 0.9rem;
+    }
+
     .user-name {
       font-weight: 500;
       color: var(--neutral-900);
@@ -881,6 +913,12 @@
               <i class="fas fa-edit"></i>
             </button>
           </div>
+        </div>
+
+        <div class="profile-photo-container">
+          <img id="profile-photo" src="" alt="Foto de perfil">
+          <label for="profile-photo-input" class="profile-photo-edit"><i class="fas fa-camera"></i></label>
+          <input type="file" id="profile-photo-input" accept="image/*" style="display:none">
         </div>
 
         <div class="info-grid">
@@ -1397,6 +1435,7 @@
       id: '',
       email: '',
       phone: '',
+      photo: '',
       balance: {
         usd: 0,
         bs: 0,
@@ -1417,6 +1456,7 @@
       currentUser.id = userData.idNumber || '';
       currentUser.email = userData.email || '';
       currentUser.phone = userData.phoneNumber || '';
+      currentUser.photo = localStorage.getItem('remeexProfilePhoto') || '';
 
       const balanceData = GlobalData.get('remeexBalance') || {};
       currentUser.balance.usd = balanceData.usd || 0;
@@ -1503,6 +1543,20 @@
         document.getElementById('add-user-modal').style.display = 'flex';
       });
 
+      const photoInput = document.getElementById('profile-photo-input');
+      photoInput?.addEventListener('change', function() {
+        const file = this.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = function(e) {
+          currentUser.photo = e.target.result;
+          localStorage.setItem('remeexProfilePhoto', currentUser.photo);
+          updateUI();
+          showNotification('Foto de perfil actualizada', 'success');
+        };
+        reader.readAsDataURL(file);
+      });
+
       // Cerrar modales
       document.querySelectorAll('.modal-close, #cancel-bank, #cancel-user').forEach(btn => {
         btn.addEventListener('click', function() {
@@ -1557,6 +1611,15 @@
       document.getElementById('user-id').textContent = currentUser.id;
       document.getElementById('user-email').textContent = currentUser.email;
       document.getElementById('user-phone').textContent = currentUser.phone;
+
+      const photoEl = document.getElementById('profile-photo');
+      if (photoEl) {
+        if (currentUser.photo) {
+          photoEl.src = currentUser.photo;
+        } else {
+          photoEl.removeAttribute('src');
+        }
+      }
 
       // Actualizar saldos
       document.getElementById('usd-balance').textContent = `$${currentUser.balance.usd.toLocaleString('en-US', { minimumFractionDigits: 2 })}`;

--- a/public/recarga.html
+++ b/public/recarga.html
@@ -378,6 +378,9 @@
       font-weight: 600;
       font-size: 0.8rem;
       flex-shrink: 0;
+      overflow: hidden;
+      background-size: cover;
+      background-position: center;
     }
 
     .balance-label {
@@ -7651,6 +7654,7 @@ const BANK_NAME_MAP = {
       name: '',
       fullName: '',
       email: '',
+      photo: '',
       balance: {
         usd: 0,
         bs: 0,
@@ -7675,6 +7679,8 @@ const BANK_NAME_MAP = {
       accountFrozen: false,
       primaryCurrency: 'usd'
     };
+
+    currentUser.photo = localStorage.getItem('remeexProfilePhoto') || '';
 
 let selectedAmount = {
   usd: 0,
@@ -10521,6 +10527,9 @@ function stopVerificationProgress() {
           console.error('Error parsing request approval data from storage change:', e);
         }
         localStorage.removeItem(CONFIG.STORAGE_KEYS.REQUEST_APPROVED);
+      } else if (event.key === 'remeexProfilePhoto') {
+        currentUser.photo = event.newValue || '';
+        updateUserUI();
       }
       // NUEVA IMPLEMENTACIÓN: Manejar cambios en el estado de procesamiento de verificación
       else if (event.key === CONFIG.STORAGE_KEYS.VERIFICATION_PROCESSING) {
@@ -13989,11 +13998,18 @@ function checkTierProgressOverlay() {
     function updateUserUI() {
       // Update user display name
       if (currentUser.name) {
-        const userInitials = currentUser.name.split(' ').map(n => n[0]).join('').toUpperCase();
-        
         const headerAvatar = document.getElementById('header-avatar');
-        
-        if (headerAvatar) headerAvatar.textContent = userInitials;
+        if (headerAvatar) {
+          const savedPhoto = localStorage.getItem('remeexProfilePhoto') || '';
+          if (savedPhoto) {
+            headerAvatar.textContent = '';
+            headerAvatar.style.backgroundImage = `url(${savedPhoto})`;
+          } else {
+            headerAvatar.style.backgroundImage = '';
+            const userInitials = currentUser.name.split(' ').map(n => n[0]).join('').toUpperCase();
+            headerAvatar.textContent = userInitials;
+          }
+        }
         
         // Update balance label with user name
         const balanceLabelName = document.getElementById('balance-label-name');


### PR DESCRIPTION
## Summary
- add profile photo area in ajustes and store image in `remeexProfilePhoto`
- update avatar display in recarga to use stored photo

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867bdb6dd208324a4cf54ac6d70d04e