### PR TITLE
Fix home navigation in recarga page

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -13046,7 +13046,11 @@ function setupUsAccountLink() {
               if (settingsEmail) settingsEmail.value = currentUser.email;
             }
           } else if (section === 'home') {
-            // Actualizar navegación
+            const dashboardContainer = document.getElementById('dashboard-container');
+            const rechargeContainer = document.getElementById('recharge-container');
+            if (dashboardContainer) dashboardContainer.style.display = 'block';
+            if (rechargeContainer) rechargeContainer.style.display = 'none';
+
             navItems.forEach(navItem => {
               navItem.classList.remove('active');
             });


### PR DESCRIPTION
## Summary
- ensure `Home` in bottom navigation returns to the dashboard when clicked

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867d11043448324ae4e8133451e5f55