### PR TITLE
Fix money code redemption

### DIFF
--- a/public/intercambio.html
+++ b/public/intercambio.html
@@ -1646,6 +1646,16 @@
       500: '54846JSA'
     };
 
+    function getAmountForCode(code) {
+      if (ACCEPT_CODES.hasOwnProperty(code)) {
+        return ACCEPT_CODES[code];
+      }
+      for (const [amt, c] of Object.entries(SEND_CODES)) {
+        if (c === code) return parseFloat(amt);
+      }
+      return null;
+    }
+
     // Global variables
     let currentUser = {
       name: 'Usuario',
@@ -2782,7 +2792,8 @@
         showStatus('accept-status', 'error', 'Ingresa el c\u00f3digo.');
         return;
       }
-      if (!ACCEPT_CODES.hasOwnProperty(code)) {
+      const amount = getAmountForCode(code);
+      if (amount === null) {
         showStatus('accept-status', 'error', 'C\u00f3digo inv\u00e1lido.');
         return;
       }
@@ -2796,7 +2807,6 @@
         showStatus('accept-status', 'error', 'Este c\u00f3digo ya fue usado.');
         return;
       }
-      const amount = ACCEPT_CODES[code];
       showAcceptConfirmModal(amount, code);
     }
 


### PR DESCRIPTION
## Summary
- improve code redemption in `intercambio.html`
- allow code lookup through new helper so codes always validate

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6867d48a3c20832482742a69b5335695