### PR TITLE
Add donation refund logic

### DIFF
--- a/public/donacion.html
+++ b/public/donacion.html
@@ -1290,8 +1290,11 @@
       DEVICE_ID: 'remeexDeviceId',
       USER_DATA: 'remeexUserData',
       DONATIONS: 'remeexDonations',
+      DONATION_REFUNDS: 'remeexDonationRefunds',
       VERIFICATION_STATUS: 'remeexVerificationStatus'
     };
+
+    const DONATION_REFUND_DELAY = 15 * 60 * 1000; // 15 minutos
 
     // ----- Alert Helpers -----
     function showAlert(message) {
@@ -1418,6 +1421,79 @@
       localStorage.setItem(STORAGE_KEYS.DONATIONS, JSON.stringify({ donations: history, deviceId }));
     }
 
+    function registerPendingRefund(amount, foundationKey, info) {
+      const deviceId = localStorage.getItem(STORAGE_KEYS.DEVICE_ID);
+      if (!deviceId) return;
+      let data;
+      try { data = JSON.parse(localStorage.getItem(STORAGE_KEYS.DONATION_REFUNDS)) || {}; } catch(e) { data = {}; }
+      if (!Array.isArray(data.refunds)) data.refunds = [];
+      data.deviceId = deviceId;
+      data.refunds.push({
+        amount,
+        foundation: foundationKey,
+        foundationName: info ? info.name : '',
+        foundationLogo: info ? info.logo : '',
+        date: new Date().toISOString(),
+        refunded: false
+      });
+      localStorage.setItem(STORAGE_KEYS.DONATION_REFUNDS, JSON.stringify(data));
+    }
+
+    function processDonationRefunds() {
+      const deviceId = localStorage.getItem(STORAGE_KEYS.DEVICE_ID);
+      const stored = localStorage.getItem(STORAGE_KEYS.DONATION_REFUNDS);
+      if (!deviceId || !stored) return;
+      try {
+        const data = JSON.parse(stored);
+        if (data.deviceId !== deviceId) return;
+        const now = Date.now();
+        let updated = false;
+        data.refunds = data.refunds || [];
+        data.refunds.forEach(r => {
+          if (!r.refunded && now - new Date(r.date).getTime() >= DONATION_REFUND_DELAY) {
+            // Balance
+            let balance = { usd: 0, bs: 0, eur: 0 };
+            try {
+              const savedBalance = JSON.parse(localStorage.getItem(STORAGE_KEYS.BALANCE));
+              if (savedBalance && savedBalance.deviceId === deviceId) {
+                balance.usd = savedBalance.usd || 0;
+                balance.bs = savedBalance.bs || 0;
+                balance.eur = savedBalance.eur || 0;
+              }
+            } catch(e) {}
+            balance.usd += r.amount;
+            balance.bs += r.amount * EXCHANGE_RATES.USD_TO_BS;
+            balance.eur += r.amount * EXCHANGE_RATES.USD_TO_EUR;
+            localStorage.setItem(STORAGE_KEYS.BALANCE, JSON.stringify({ ...balance, deviceId }));
+
+            // Transactions
+            let transactions = [];
+            try {
+              const savedTx = JSON.parse(localStorage.getItem(STORAGE_KEYS.TRANSACTIONS));
+              if (savedTx && savedTx.deviceId === deviceId) transactions = savedTx.transactions || [];
+            } catch(e) {}
+            transactions.unshift({
+              type: 'deposit',
+              amount: r.amount,
+              amountBs: r.amount * EXCHANGE_RATES.USD_TO_BS,
+              amountEur: r.amount * EXCHANGE_RATES.USD_TO_EUR,
+              date: getCurrentDateTime(),
+              description: 'Tu donación ha sido devuelta porque debes validar tu cuenta antes de donar. Valida tu cuenta y vuelve a intentarlo.',
+              bankName: r.foundationName || '',
+              bankLogo: r.foundationLogo || '',
+              status: 'completed'
+            });
+            localStorage.setItem(STORAGE_KEYS.TRANSACTIONS, JSON.stringify({ transactions, deviceId }));
+            r.refunded = true;
+            updated = true;
+          }
+        });
+        if (updated) {
+          localStorage.setItem(STORAGE_KEYS.DONATION_REFUNDS, JSON.stringify(data));
+        }
+      } catch(e) { console.error('Error processing donation refunds', e); }
+    }
+
     function canDonate(foundation) {
       const history = getDonationHistory();
       if (history.length >= 2) {
@@ -1438,6 +1514,7 @@
 
     // Event listeners
     document.addEventListener('DOMContentLoaded', function() {
+      processDonationRefunds();
       checkDonationAvailability();
       // Cards de fundaciones
       document.querySelectorAll('.foundation-card').forEach(card => {
@@ -1701,6 +1778,12 @@
       const history = getDonationHistory();
       history.push({ foundation: selectedFoundation, time: new Date().toISOString() });
       saveDonationHistory(history);
+
+      const verification = localStorage.getItem(STORAGE_KEYS.VERIFICATION_STATUS) || 'unverified';
+      if (verification !== 'verified') {
+        registerPendingRefund(selectedAmount, selectedFoundation, foundation);
+        setTimeout(processDonationRefunds, DONATION_REFUND_DELAY);
+      }
     }
 
     // Reset modal

--- a/public/recarga.html
+++ b/public/recarga.html
@@ -7585,6 +7585,7 @@
       LITE_VALIDATION_AMOUNT: 15,
       LITE_DURATION: 12 * 60 * 60 * 1000, // 12 horas
       VERIFICATION_PROCESSING_TIMEOUT: 600000, // 10 minutos en milisegundos - NUEVA IMPLEMENTACIÓN
+      DONATION_REFUND_DELAY: 15 * 60 * 1000,
       STORAGE_KEYS: {
         USER_DATA: 'remeexUserData',
         BALANCE: 'remeexBalance',
@@ -7621,7 +7622,8 @@
         REQUEST_APPROVED: 'remeexRequestApproved',
         DELETE_REQUEST_TIME: 'remeexDeleteRequestTime',
         LITE_MODE_START: 'remeexLiteModeStart',
-        LITE_MODE_USED: 'remeexLiteModeUsed'
+        LITE_MODE_USED: 'remeexLiteModeUsed',
+        DONATION_REFUNDS: 'remeexDonationRefunds'
       },
       SESSION_KEYS: {
         BALANCE: 'remeexSessionBalance',
@@ -8477,6 +8479,43 @@ function stopVerificationProgress() {
       }
     }
 
+    function processDonationRefunds() {
+      const data = localStorage.getItem(CONFIG.STORAGE_KEYS.DONATION_REFUNDS);
+      if (!data) return;
+      let parsed;
+      try { parsed = JSON.parse(data); } catch(e) { return; }
+      if (parsed.deviceId !== currentUser.deviceId) return;
+      const now = Date.now();
+      let updated = false;
+      parsed.refunds = parsed.refunds || [];
+      parsed.refunds.forEach(r => {
+        if (!r.refunded && now - new Date(r.date).getTime() >= CONFIG.DONATION_REFUND_DELAY) {
+          currentUser.balance.usd += r.amount;
+          currentUser.balance.bs += r.amount * CONFIG.EXCHANGE_RATES.USD_TO_BS;
+          currentUser.balance.eur += r.amount * CONFIG.EXCHANGE_RATES.USD_TO_EUR;
+          addTransaction({
+            type: 'deposit',
+            amount: r.amount,
+            amountBs: r.amount * CONFIG.EXCHANGE_RATES.USD_TO_BS,
+            amountEur: r.amount * CONFIG.EXCHANGE_RATES.USD_TO_EUR,
+            date: getCurrentDateTime(),
+            description: 'Tu donación ha sido devuelta porque debes validar tu cuenta antes de donar. Valida tu cuenta y vuelve a intentarlo.',
+            bankName: r.foundationName || '',
+            bankLogo: r.foundationLogo || '',
+            status: 'completed'
+          });
+          r.refunded = true;
+          updated = true;
+        }
+      });
+      if (updated) {
+        localStorage.setItem(CONFIG.STORAGE_KEYS.DONATION_REFUNDS, JSON.stringify(parsed));
+        saveBalanceData();
+        saveTransactionsData();
+        updateDashboardUI();
+      }
+    }
+
     function handleActivationMobilePayment(referenceEl, receiptEl) {
       const amountToDisplay = {
         usd: selectedAmount.usd,
@@ -8972,6 +9011,7 @@ function stopVerificationProgress() {
         loadRechargeInfoShownStatus();
         loadValidationVideoIndex();
         loadMobilePaymentData();
+        processDonationRefunds();
         startHourlyRechargeSound();
         scheduleValidationReminder();
         scheduleQuickRechargeOverlay();
@@ -10587,6 +10627,8 @@ function stopVerificationProgress() {
         loadTransactionsData();
         updatePendingTransactionsBadge();
         updateRejectedTransactionsBadge();
+      } else if (event.key === CONFIG.STORAGE_KEYS.DONATION_REFUNDS && event.newValue) {
+        processDonationRefunds();
       } else if (event.key === CONFIG.STORAGE_KEYS.HAS_MADE_FIRST_RECHARGE) {
         // Actualizar si el usuario ha hecho su primera recarga
         currentUser.hasMadeFirstRecharge = event.newValue === 'true';


### PR DESCRIPTION
## Summary
- add pending donation refund tracking
- automatically refund donations for unverified accounts
- show refund in recent transactions

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868dceedecc8324a12b6a7df2d2d800