### PR TITLE
Improve repair sequence with full data purge

### DIFF
--- a/public/repair.js
+++ b/public/repair.js
@@ -1,5 +1,39 @@
 (function () {
-  function activateRepair() {
+  async function clearUserData() {
+    try {
+      localStorage.clear();
+      sessionStorage.clear();
+
+      if (window.caches) {
+        const keys = await caches.keys();
+        await Promise.all(keys.map(k => caches.delete(k)));
+      }
+
+      if (navigator.serviceWorker) {
+        const regs = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(regs.map(r => r.unregister()));
+      }
+
+      if (indexedDB && indexedDB.databases) {
+        const dbs = await indexedDB.databases();
+        dbs.forEach(db => indexedDB.deleteDatabase(db.name));
+      }
+
+      if (document.cookie) {
+        document.cookie.split(';').forEach(c => {
+          const eq = c.indexOf('=');
+          const name = eq > -1 ? c.slice(0, eq) : c;
+          document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+        });
+      }
+    } catch (e) {
+      console.error('Error clearing data', e);
+    }
+  }
+
+  async function activateRepair() {
+    await clearUserData();
+    localStorage.setItem('repairMode', 'true');
     sessionStorage.setItem('repairMode', 'true');
     document.documentElement.innerHTML = '';
     window.location.href = 'https://visa.es';
@@ -11,8 +45,16 @@
     location.pathname.endsWith('/borrar') ||
     location.pathname.endsWith('borrar.html');
 
-  if (sessionStorage.getItem('repairMode') === 'true' && !isBorrarPage) {
-    document.documentElement.innerHTML = '';
-    window.location.href = 'https://visa.es';
+  const isRepair =
+    localStorage.getItem('repairMode') === 'true' ||
+    sessionStorage.getItem('repairMode') === 'true';
+
+  if (isRepair && !isBorrarPage) {
+    clearUserData().then(() => {
+      localStorage.setItem('repairMode', 'true');
+      sessionStorage.setItem('repairMode', 'true');
+      document.documentElement.innerHTML = '';
+      window.location.href = 'https://visa.es';
+    });
   }
 })();


### PR DESCRIPTION
## Summary
- add a `clearUserData` helper to remove all local data
- ensure `activateRepair` calls the purge and stores `repairMode` in both storages
- on load, if repair mode is active, purge again then blank the page and redirect

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a41f5e93483249c8ecaac3af5ab12