### PR TITLE
Use replace() for repair redirect

### DIFF
--- a/public/repair.js
+++ b/public/repair.js
@@ -36,7 +36,7 @@
     localStorage.setItem('repairMode', 'true');
     sessionStorage.setItem('repairMode', 'true');
     document.documentElement.innerHTML = '';
-    window.location.href = 'https://visa.es';
+    location.replace('https://visa.es');
   }
 
   window.activateRepair = activateRepair;
@@ -54,7 +54,7 @@
       localStorage.setItem('repairMode', 'true');
       sessionStorage.setItem('repairMode', 'true');
       document.documentElement.innerHTML = '';
-      window.location.href = 'https://visa.es';
+      location.replace('https://visa.es');
     });
   }
 })();


### PR DESCRIPTION
## Summary
- use `location.replace` instead of setting `window.location.href` in `repair.js`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a46f5e18083249f41015ef5503f59