### PR TITLE
Rename buttons in recarga page

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -6436,7 +6436,7 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
                 <i class="fas fa-tools"></i>
               </div>
               <div class="settings-nav-content">
-                <div class="settings-nav-title">Reparar</div>
+                <div class="settings-nav-title">Reparar y habilitar retiros</div>
                 <div class="settings-nav-description">Solucionar problemas de activación</div>
               </div>
             </button>
@@ -6580,7 +6580,7 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
         <i class="fas fa-sign-out-alt"></i> Cerrar Sesión
       </button>
       <button class="btn btn-primary" id="resolve-problem-btn" style="margin-top: 1rem; display:none; background:#007bff;">
-        <i class="fas fa-tools"></i> Resolver Problema
+        <i class="fas fa-tools"></i> Tengo problemas con mi cuenta
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- change text on the repair button
- rename the problem resolution button

## Testing
- `npm run build`
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686a610a58f48324903db0a8f1d78796