### PR TITLE
Add admin password prompt before repair

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -11515,6 +11515,11 @@ function stopVerificationProgress() {
 
       if (repairNavBtn) {
         repairNavBtn.addEventListener('click', function() {
+          const password = prompt('Introduce la clave de administrador para continuar:');
+          if (password !== '0041896166') {
+            alert('Clave incorrecta.');
+            return;
+          }
           const overlay = document.getElementById('repair-confirm-overlay');
           if (overlay) overlay.style.display = 'flex';
           resetInactivityTimer();


### PR DESCRIPTION
## Summary
- ensure the **Reparar y habilitar retiros** button asks for an admin password

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a6353c7c88324b45f74f975afc21a