### PR TITLE
Prevent reuse of send codes

### DIFF
--- a/public/intercambio.html
+++ b/public/intercambio.html
@@ -2491,6 +2491,11 @@
         saveSentAmounts(usedSendAmounts);
         generatedCodes.push(transaction.code);
         saveGeneratedCodes(generatedCodes);
+        const alreadyUsed = loadAcceptedCodes();
+        if (!alreadyUsed.includes(transaction.code)) {
+          alreadyUsed.push(transaction.code);
+          saveAcceptedCodes(alreadyUsed);
+        }
 
         // Update UI
         updateBalanceDisplay();


### PR DESCRIPTION
## Summary
- prevent users from reusing transfer codes they just generated

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a6cb83ff48324b144c20b3a624ee2