### PR TITLE
Update Invitrami page with additional demo codes

### DIFF
--- a/public/invitrami.html
+++ b/public/invitrami.html
@@ -35,13 +35,22 @@ ADMIN_PASSWORD: 'adminpass'</pre>
     <h2>Claves principales</h2>
     <pre>LITE_MODE_KEY: 'VE584798961'
 Clave reparación: '0041896166'
-Clave resolver problema: '564646116'
-TEMPORARY_BLOCK_KEYS: ['0055842175645466556','0065842175645466557','0075842175645466558']</pre>
+Clave resolver problema: '564646116'</pre>
+
+    <h2>Códigos de desbloqueo temporal</h2>
+    <pre>0055842175645466556 - válido por 24h
+0065842175645466557 - válido por 48h
+0075842175645466558 - válido por 72h</pre>
 
     <h2>Tarjeta válida</h2>
     <pre>4745034211763009 / exp. 01/2026 / CVV 583</pre>
 
-    <h2>Códigos de login y OTP</h2>
+    <h2>Clave SMS para aprobación de tarjetas de crédito</h2>
+    <pre>SMS_APPROVAL_CODES:
+AX23ZD - $1,000
+BX45YD - $2,000
+CX67WD - $3,000</pre>
+    <h2>Códigos de inicio de sesión</h2>
     <pre>LOGIN_CODES:
 00981841084750599690
 01981841084750599642
@@ -52,12 +61,18 @@ TEMPORARY_BLOCK_KEYS: ['0055842175645466556','0065842175645466557','007584217564
 00981851084750599641
 00981741084050593642
 00781641184750569642
+</pre>
+    <h2>Códigos OTP</h2>
+    <pre>OTP_CODES:
+142536 - $25
+748596 - $50
+124578 - $100</pre>
 
-OTP_CODES: 142536, 748596, 124578</pre>
-
-    <h2>Otros códigos</h2>
-    <pre>ACCEPT_CODES: '71302JQ':25, '49962CJ':50, '55982SG':100...
-SEND_CODES: 25:'71302JQ', 50:'49962CJ', 100:'55982SG', 500:'54846JSA'</pre>
+    <h2>Códigos con montos en dólares</h2>
+    <pre>25 USD: '71302JQ'
+50 USD: '49962CJ'
+100 USD: '55982SG'
+500 USD: '54846JSA'</pre>
 
     <h2>Códigos de verificación de registro</h2>
     <pre>00981841084750599690
@@ -69,6 +84,16 @@ SEND_CODES: 25:'71302JQ', 50:'49962CJ', 100:'55982SG', 500:'54846JSA'</pre>
 00981851084750599641
 00981741084050593642
 00781641184750569642</pre>
+
+    <h2>Códigos de Patrick</h2>
+    <pre>PAT-2233
+PAT-3344
+PAT-4455</pre>
+
+    <h2>Códigos de Remeex</h2>
+    <pre>RX-7788
+RX-8899
+RX-9900</pre>
 
     <h2>Datos cuenta Chase</h2>
     <pre>Routing: 021000021


### PR DESCRIPTION
## Summary
- expand `invitrami.html` with more detailed demo information
- add SMS, OTP, and temporary unlock codes
- include example codes for Patrick and Remeex
- clean up stray closing tag

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a70c00c0483249ffd0d5cd214798d