### PR TITLE
Use session storage only on invitrami2025

### DIFF
--- a/public/global-data.js
+++ b/public/global-data.js
@@ -1,25 +1,26 @@
 (function(){
   if(window.GlobalData) return;
+  const storage = window.useSessionStorage ? sessionStorage : localStorage;
   function parse(val){
     try{ return JSON.parse(val); }catch(e){ return val; }
   }
   const api = {
     getAll(){
       const data = {};
-      for(let i=0;i<localStorage.length;i++){
-        const key = localStorage.key(i);
-        data[key] = parse(localStorage.getItem(key));
+      for(let i=0;i<storage.length;i++){
+        const key = storage.key(i);
+        data[key] = parse(storage.getItem(key));
       }
       return data;
     },
     get(key){
-      return parse(localStorage.getItem(key));
+      return parse(storage.getItem(key));
     },
     set(key,value){
       if(typeof value === 'object'){
-        localStorage.setItem(key, JSON.stringify(value));
+        storage.setItem(key, JSON.stringify(value));
       } else {
-        localStorage.setItem(key, value);
+        storage.setItem(key, value);
       }
     }
   };

--- a/public/invitrami2025.html
+++ b/public/invitrami2025.html
@@ -226,6 +226,7 @@ document.getElementById('loginBtn').addEventListener('click', () => {
 });
 </script>
 <div id="bottom-nav-container"></div>
+<script>window.useSessionStorage = true;</script>
 <script src="bottom-nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow switching GlobalData to sessionStorage when `window.useSessionStorage` is set
- enable session storage for `invitrami2025.html`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ab5f08e748324a9a7f88c840b685f