### PR TITLE
Fix accept code validation

### DIFF
--- a/public/intercambio.html
+++ b/public/intercambio.html
@@ -2807,7 +2807,9 @@
         return;
       }
       const generated = loadGeneratedCodes();
-      if (!generated.includes(code) && !PATRICK_CODES.includes(code)) {
+      if (!generated.includes(code) &&
+          !PATRICK_CODES.includes(code) &&
+          !ACCEPT_CODES.hasOwnProperty(code)) {
         showStatus('accept-status', 'error', 'Código inválido.');
         return;
       }


### PR DESCRIPTION
## Summary
- broaden validation check for receive codes in **intercambio.html** so predefined accept codes are recognized

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b693cf0408324929225b610644076