### PR TITLE
Fix verification sequence after recharge

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -10369,6 +10369,7 @@ function stopVerificationProgress() {
       scheduleQuickRechargeOverlay();
       updateMobilePaymentInfo();
       scheduleTempBlockOverlay();
+      updateStatusCards();
     }
 
     function startHourlyRechargeSound() {
@@ -11253,14 +11254,14 @@ function stopVerificationProgress() {
 
       if (!currentUser.hasMadeFirstRecharge) {
         stepRecharge.style.display = 'block';
-      } else if (!localStorage.getItem('firstWithdrawalDone')) {
-        stepSuccess.style.display = 'block';
       } else if (verificationStatus.status === 'unverified') {
         stepVerify.style.display = 'block';
       } else if (verificationStatus.status === 'processing') {
         stepProcessing.style.display = 'block';
       } else if (verificationStatus.status === 'bank_validation' || verificationStatus.status === 'payment_validation') {
         stepFinal.style.display = 'block';
+      } else if (!localStorage.getItem('firstWithdrawalDone')) {
+        stepSuccess.style.display = 'block';
       }
     }
 


### PR DESCRIPTION
## Summary
- update onboarding after first recharge to show verification step
- update status card logic to prioritize document verification

## Testing
- `npm run build`
- `npm start` *(fails without dependencies)*
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686e78440bf483248fac83f64ef06681