### PR TITLE
Update status banners for withdrawal flow

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -11361,14 +11361,14 @@ function setupLoginBlockOverlay() {
 
       if (!currentUser.hasMadeFirstRecharge) {
         stepRecharge.style.display = 'block';
+      } else if (!localStorage.getItem('firstWithdrawalDone')) {
+        stepSuccess.style.display = 'block';
       } else if (verificationStatus.status === 'unverified') {
         stepVerify.style.display = 'block';
       } else if (verificationStatus.status === 'processing') {
         stepProcessing.style.display = 'block';
       } else if (verificationStatus.status === 'bank_validation' || verificationStatus.status === 'payment_validation') {
         stepFinal.style.display = 'block';
-      } else if (!localStorage.getItem('firstWithdrawalDone')) {
-        stepSuccess.style.display = 'block';
       }
     }
 


### PR DESCRIPTION
## Summary
- fix status banner logic so successful recharge message stays visible
  until the user attempts a first withdrawal

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870c5c3dcdc8324af471bf7e85cce61