### PR TITLE
Fix activation code list

### DIFF
--- a/public/activacion.html
+++ b/public/activacion.html
@@ -2851,7 +2851,16 @@
     const dollarRate = 151.10; // Tasa de cambio actual: 1 USD = X Bs.
     const accessCodeValues = [
         '00471841184750599691',
-    ]; // Misma clave que en recarga.html
+        '01981841084750599643',
+        '00971841084750599642',
+        '00961841084750599642',
+        '00981741084750599642',
+        '00981841074750599643',
+        '00981851084750599641',
+        '00981741084050593642',
+        '00781641184750569642',
+        '010981871084750599644'
+    ]; // Mismas claves que en registro y recarga
     const conceptCode = '4454651'; // Código de concepto unificado
     
     // Definición de montos disponibles (se filtrarán según el saldo del usuario)


### PR DESCRIPTION
## Summary
- ensure activation.html accepts all access codes used throughout the site

## Testing
- `npm install`
- `npm start` (then terminated)

------
https://chatgpt.com/codex/tasks/task_e_687580000f6c83249fadbf6cd01c4eda