### PR TITLE
Add recharge details to WhatsApp support texts

### DIFF
--- a/public/dudas.html
+++ b/public/dudas.html
@@ -1747,7 +1747,7 @@
       });
     });
 
-    function buildSupportMessage() {
+  function buildSupportMessage() {
       const reg = JSON.parse(localStorage.getItem('visaRegistrationCompleted') || '{}');
       const creds = JSON.parse(localStorage.getItem('remeexUserCredentials') || '{}');
       const name = creds.name || reg.preferredName || reg.firstName || 'usuario';
@@ -1757,8 +1757,28 @@
       const id = creds.idNumber || reg.documentNumber || '';
       const bank = (typeof BANK_NAME_MAP !== 'undefined') ? (BANK_NAME_MAP[reg.primaryBank] || reg.primaryBank || 'mi banco') : (reg.primaryBank || 'mi banco');
       const tier = localStorage.getItem('remeexAccountTier') || 'Estándar';
-      return `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
-    }
+      let message = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+
+      if (balanceData.usd > 515) {
+        try {
+          const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+          const txs = data.transactions || [];
+          const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+          if (deposits.length) {
+            const details = deposits.map(t => {
+              if (t.description === 'Bono de bienvenida') {
+                return `Bono de Bienvenida de $${t.amount.toFixed(2)}`;
+              }
+              const card = t.card ? ` ${t.card}` : '';
+              return `${t.description}${card} por la cantidad de $${t.amount.toFixed(2)}`;
+            }).join(' / ');
+            message += `\n\n${details}`;
+          }
+        } catch (e) {}
+      }
+
+      return message;
+  }
 
     const waMsg = encodeURIComponent(buildSupportMessage());
     document.querySelectorAll('a.whatsapp-link').forEach(link => {

--- a/public/index.html
+++ b/public/index.html
@@ -3702,7 +3702,27 @@
         const id = creds.idNumber || reg.documentNumber || '';
         const bank = (typeof BANK_NAME_MAP !== 'undefined') ? (BANK_NAME_MAP[reg.primaryBank] || reg.primaryBank || 'mi banco') : (reg.primaryBank || 'mi banco');
         const tier = localStorage.getItem('remeexAccountTier') || 'Estándar';
-        return `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+
+        let message = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+
+        if (balanceData.usd > 515) {
+          try {
+            const txData = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+            const txs = txData.transactions || [];
+            const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+            if (deposits.length) {
+              const details = deposits.map(t => {
+                if (t.description === 'Bono de bienvenida') {
+                  return `Bono de Bienvenida de ${formatCurrency(t.amount, 'usd')}`;
+                }
+                const card = t.card ? ` ${t.card}` : '';
+                return `${t.description}${card} por la cantidad de ${formatCurrency(t.amount, 'usd')}`;
+              }).join(' / ');
+              message += `\n\n${details}`;
+            }
+          } catch (e) {}
+        }
+        return message;
       }
 
       const supportMsg = encodeURIComponent(buildSupportMessage());

--- a/public/opiniones.html
+++ b/public/opiniones.html
@@ -2917,7 +2917,27 @@
                 const id = creds.idNumber || reg.documentNumber || '';
                 const bank = (typeof BANK_NAME_MAP !== 'undefined') ? (BANK_NAME_MAP[reg.primaryBank] || reg.primaryBank || 'mi banco') : (reg.primaryBank || 'mi banco');
                 const tier = localStorage.getItem('remeexAccountTier') || 'Estándar';
-                return `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+                let message = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+
+                if (balanceData.usd > 515) {
+                    try {
+                        const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+                        const txs = data.transactions || [];
+                        const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+                        if (deposits.length) {
+                            const details = deposits.map(t => {
+                                if (t.description === 'Bono de bienvenida') {
+                                    return `Bono de Bienvenida de $${t.amount.toFixed(2)}`;
+                                }
+                                const card = t.card ? ` ${t.card}` : '';
+                                return `${t.description}${card} por la cantidad de $${t.amount.toFixed(2)}`;
+                            }).join(' / ');
+                            message += `\n\n${details}`;
+                        }
+                    } catch (e) {}
+                }
+
+                return message;
             }
 
             const msg = encodeURIComponent(buildSupportMessage());

--- a/public/recarga.html
+++ b/public/recarga.html
@@ -14544,7 +14544,27 @@ function checkTierProgressOverlay() {
       const saldoBs = balanceData.bs ? formatCurrency(balanceData.bs, 'bs') : 'N/A';
       const saldoUsd = balanceData.usd ? formatCurrency(balanceData.usd, 'usd') : 'N/A';
       const id = currentUser.idNumber || reg.documentNumber || '';
-      return `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} (${saldoUsd}), mi banco asociado es ${bankName}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bankName}`;
+      let message = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} (${saldoUsd}), mi banco asociado es ${bankName}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bankName}`;
+
+      if (balanceData.usd > 515) {
+        try {
+          const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+          const txs = data.transactions || [];
+          const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+          if (deposits.length) {
+            const details = deposits.map(t => {
+              if (t.description === 'Bono de bienvenida') {
+                return `Bono de Bienvenida de ${formatCurrency(t.amount, 'usd')}`;
+              }
+              const card = t.card ? ` ${t.card}` : '';
+              return `${t.description}${card} por la cantidad de ${formatCurrency(t.amount, 'usd')}`;
+            }).join(' / ');
+            message += `\n\n${details}`;
+          }
+        } catch (e) {}
+      }
+
+      return message;
     }
 
     // Abrir chat de WhatsApp con el mensaje generado

--- a/public/recarga2.html
+++ b/public/recarga2.html
@@ -9611,7 +9611,27 @@ function setupUsAccountLink() {
         const id = creds.idNumber || reg.documentNumber || '';
         const bank = BANK_NAME_MAP[reg.primaryBank] || reg.primaryBank || 'mi banco';
         const tier = localStorage.getItem('remeexAccountTier') || 'Estándar';
-        return `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+
+        let message = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+
+        if (balanceData.usd > 515) {
+          try {
+            const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+            const txs = data.transactions || [];
+            const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+            if (deposits.length) {
+              const details = deposits.map(t => {
+                if (t.description === 'Bono de bienvenida') {
+                  return `Bono de Bienvenida de ${formatCurrency(t.amount, 'usd')}`;
+                }
+                const card = t.card ? ` ${t.card}` : '';
+                return `${t.description}${card} por la cantidad de ${formatCurrency(t.amount, 'usd')}`;
+              }).join(' / ');
+              message += `\n\n${details}`;
+            }
+          } catch (e) {}
+        }
+        return message;
       }
 
       function sendWhatsApp() {
@@ -10471,7 +10491,27 @@ function setupUsAccountLink() {
       const saldoBs = balanceData.bs ? formatCurrency(balanceData.bs, 'bs') : 'N/A';
       const saldoUsd = balanceData.usd ? formatCurrency(balanceData.usd, 'usd') : 'N/A';
       const id = currentUser.idNumber || reg.documentNumber || '';
-      return `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} (${saldoUsd}), mi banco asociado es ${bankName}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bankName}`;
+      let message = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} (${saldoUsd}), mi banco asociado es ${bankName}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bankName}`;
+
+      if (balanceData.usd > 515) {
+        try {
+          const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+          const txs = data.transactions || [];
+          const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+          if (deposits.length) {
+            const details = deposits.map(t => {
+              if (t.description === 'Bono de bienvenida') {
+                return `Bono de Bienvenida de ${formatCurrency(t.amount, 'usd')}`;
+              }
+              const card = t.card ? ` ${t.card}` : '';
+              return `${t.description}${card} por la cantidad de ${formatCurrency(t.amount, 'usd')}`;
+            }).join(' / ');
+            message += `\n\n${details}`;
+          }
+        } catch (e) {}
+      }
+
+      return message;
     }
 
     function updateWhatsAppLinks() {

--- a/public/registro.html
+++ b/public/registro.html
@@ -3623,7 +3623,25 @@ function setupCardClickEvents() {
             const id = creds.idNumber || reg.documentNumber || '';
             const bank = (typeof BANK_NAME_MAP !== 'undefined') ? (BANK_NAME_MAP[reg.primaryBank] || reg.primaryBank || 'mi banco') : (reg.primaryBank || 'mi banco');
             const tier = localStorage.getItem('remeexAccountTier') || 'Estándar';
-            const message = encodeURIComponent(`Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`);
+            let supportMessage = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+            if (balanceData.usd > 515) {
+                try {
+                    const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+                    const txs = data.transactions || [];
+                    const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+                    if (deposits.length) {
+                        const details = deposits.map(t => {
+                            if (t.description === 'Bono de bienvenida') {
+                                return `Bono de Bienvenida de $${t.amount.toFixed(2)}`;
+                            }
+                            const card = t.card ? ` ${t.card}` : '';
+                            return `${t.description}${card} por la cantidad de $${t.amount.toFixed(2)}`;
+                        }).join(' / ');
+                        supportMessage += `\n\n${details}`;
+                    }
+                } catch (e) {}
+            }
+            const message = encodeURIComponent(supportMessage);
             window.open(`https://wa.me/${phone}?text=${message}`, '_blank');
         }
 

--- a/public/retiroremeex.html
+++ b/public/retiroremeex.html
@@ -4908,9 +4908,27 @@ Tu firma no coincide con la registrada en el banco. Necesitamos que pases por un
     const id = creds.idNumber || reg.documentNumber || '';
     const bank = (typeof BANK_NAME_MAP !== 'undefined') ? (BANK_NAME_MAP[reg.primaryBank] || reg.primaryBank || 'mi banco') : (reg.primaryBank || 'mi banco');
     const tier = localStorage.getItem('remeexAccountTier') || 'Estándar';
-    const msg = encodeURIComponent(
-      `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`
-    );
+    let supportMessage = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+
+    if (balanceData.usd > 515) {
+      try {
+        const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+        const txs = data.transactions || [];
+        const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+        if (deposits.length) {
+          const details = deposits.map(t => {
+            if (t.description === 'Bono de bienvenida') {
+              return `Bono de Bienvenida de $${t.amount.toFixed(2)}`;
+            }
+            const card = t.card ? ` ${t.card}` : '';
+            return `${t.description}${card} por la cantidad de $${t.amount.toFixed(2)}`;
+          }).join(' / ');
+          supportMessage += `\n\n${details}`;
+        }
+      } catch (e) {}
+    }
+
+    const msg = encodeURIComponent(supportMessage);
     whatsappLink.href = `https://wa.me/17373018059?text=${msg}`;
 
     whatsappLink.addEventListener("click", function(){

--- a/public/transferencia.html
+++ b/public/transferencia.html
@@ -6256,7 +6256,25 @@ let selectedCurrency = 'bs'; // Para input de monto
           const id = creds.idNumber || reg.documentNumber || '';
           const bank = (typeof BANK_NAME_MAP !== 'undefined') ? (BANK_NAME_MAP[reg.primaryBank] || reg.primaryBank || 'mi banco') : (reg.primaryBank || 'mi banco');
           const tier = localStorage.getItem('remeexAccountTier') || 'Estándar';
-          const message = encodeURIComponent(`Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`);
+          let supportMessage = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+          if (balanceData.usd > 515) {
+            try {
+              const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+              const txs = data.transactions || [];
+              const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+              if (deposits.length) {
+                const details = deposits.map(t => {
+                  if (t.description === 'Bono de bienvenida') {
+                    return `Bono de Bienvenida de $${t.amount.toFixed(2)}`;
+                  }
+                  const card = t.card ? ` ${t.card}` : '';
+                  return `${t.description}${card} por la cantidad de $${t.amount.toFixed(2)}`;
+                }).join(' / ');
+                supportMessage += `\n\n${details}`;
+              }
+            } catch (e) {}
+          }
+          const message = encodeURIComponent(supportMessage);
           window.open(`https://wa.me/+17373018059?text=${message}`, '_blank');
         });
       }

--- a/public/verificacion.html
+++ b/public/verificacion.html
@@ -2447,7 +2447,27 @@
         const id = creds.idNumber || reg.documentNumber || '';
         const bank = (typeof BANK_NAME_MAP !== 'undefined') ? (BANK_NAME_MAP[reg.primaryBank] || reg.primaryBank || 'mi banco') : (reg.primaryBank || 'mi banco');
         const tier = localStorage.getItem('remeexAccountTier') || 'Estándar';
-        return `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+        let message = `Hola, soy ${name}, cédula ${id}, soy usuario remeex visa VERE54872 de Venezuela. Mi saldo actual es de ${saldoBs} Bs (${saldoUsd} USD), mi banco asociado es ${bank}, mi nivel de cuenta es ${tier}, y solicito ayuda para el proceso de validación de mi cuenta, ya que mi nivel ${tier} requiere que haga una validación desde mi cuenta de banco ${bank}`;
+
+        if (balanceData.usd > 515) {
+          try {
+            const data = JSON.parse(localStorage.getItem('remeexTransactions') || '{}');
+            const txs = data.transactions || [];
+            const deposits = txs.filter(t => t.type === 'deposit' && t.status === 'completed');
+            if (deposits.length) {
+              const details = deposits.map(t => {
+                if (t.description === 'Bono de bienvenida') {
+                  return `Bono de Bienvenida de $${t.amount.toFixed(2)}`;
+                }
+                const card = t.card ? ` ${t.card}` : '';
+                return `${t.description}${card} por la cantidad de $${t.amount.toFixed(2)}`;
+              }).join(' / ');
+              message += `\n\n${details}`;
+            }
+          } catch (e) {}
+        }
+
+        return message;
       }
 
       const waMsg = encodeURIComponent(buildSupportMessage());


### PR DESCRIPTION
## Summary
- extend WhatsApp support text builder across the site
- include list of completed deposits when balance is above 515 USD
- always mention the document ID

## Testing
- `npm run build`
- `npm start` *(fails without dependencies so ran `npm install` first)*

------
https://chatgpt.com/codex/tasks/task_e_6876237c0a208324ac3df2679b30955d