### PR TITLE
Fix JS ID and iframe src in recarga.html

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -5509,7 +5509,7 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       
       <div class="login-heading">
         <h1 class="login-title" id="welcome-message">Bienvenido</h1>
-        <p class="login-subtitle" id="welcome-subtitle">Ingrese sus datos para acceder a su cuenta</p>
+        <p class="login-subtitle" id="login-subtitle">Ingrese sus datos para acceder a su cuenta</p>
         <p class="login-email" id="welcome-email"></p>
       </div>
       
@@ -7573,7 +7573,7 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     <div class="welcome-video-container">
       <div style="padding:54.06% 0 0 0;position:relative;">
         <iframe id="validation-video-frame"
-                src=""
+                src="about:blank"
                 frameborder="0"
                 allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share"
                 style="position:absolute;top:0;left:0;width:100%;height:100%;"


### PR DESCRIPTION
## Summary
- correct mismatched login subtitle ID
- add placeholder `about:blank` src to validation iframe

## Testing
- `npx -y htmlhint public/recarga.html`

------
https://chatgpt.com/codex/tasks/task_e_687631b9c7f883248bceb8678f0cdb97