### PR TITLE
Fix balance card layout

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -3389,7 +3389,10 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       margin-bottom: 0.25rem;
     }
 
-    .balance-card {
+    /* Solo las tarjetas que aparecen dentro del flujo de validación
+       necesitan la distribución centrada en columna. Ajustamos el
+       selector para no afectar la tarjeta principal de saldo */
+    .balance-flow .balance-card {
       display: flex;
       flex-direction: column;
       align-items: center;


### PR DESCRIPTION
## Summary
- avoid overriding the main balance card layout by adjusting CSS selector

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68768de14ca08324b182700e57299fbe