### PR TITLE
Improve pending validation flow layout

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -3405,6 +3405,30 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       font-size: 0.75rem;
     }
 
+    /* Mini balance cards shown during pending validation */
+    .balance-flow .balance-card {
+      background: var(--neutral-100);
+      border-radius: var(--radius-md);
+      padding: 0.4rem;
+      box-shadow: var(--shadow-sm);
+      width: 60px;
+    }
+
+    .balance-flow .bank-logo-mini {
+      height: 20px;
+      width: auto;
+      margin-left: 0;
+    }
+
+    .balance-flow .balance-amount {
+      font-size: 0.65rem;
+    }
+
+    .balance-flow .visa-arrow {
+      font-size: 1rem;
+      color: var(--primary);
+    }
+
     @keyframes visaFlowArrow {
       0%, 100% { transform: translateX(0); opacity: 0.8; }
       50% { transform: translateX(8px); opacity: 1; }


### PR DESCRIPTION
## Summary
- tweak styles for `validation-balance-flow`
- show mini balance cards inside the pending validation card

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68769468344083248a059c0ff83b13c9