### PR TITLE
Fix progress validation card graphics

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -3401,15 +3401,30 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       margin-bottom: 0.25rem;
     }
 
-    .balance-card {
+    .balance-flow .balance-card {
+      background: var(--neutral-100);
+      border-radius: var(--radius-sm);
+      padding: 0.5rem;
+      box-shadow: var(--shadow-sm);
       display: flex;
       flex-direction: column;
       align-items: center;
       gap: 0.25rem;
     }
 
-    .balance-amount {
+    .balance-flow .bank-logo-mini {
+      height: 20px;
+    }
+
+    .balance-flow .balance-amount {
+      font-size: 0.75rem;
       font-weight: 600;
+    }
+
+    .balance-flow .visa-arrow {
+      color: var(--primary);
+      font-size: 1rem;
+      animation: visaFlowArrow 2s cubic-bezier(0.65, 0, 0.35, 1) infinite;
     }
 
     .balance-flow-text {


### PR DESCRIPTION
## Summary
- adjust CSS for `balance-flow` cards so validation graphics fit within card

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876962fb27c8324b7b71d86a2c0ad80