### PR TITLE
Adjust login logos spacing

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -2403,12 +2403,13 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       width: 100%;
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
+      gap: 0.8rem;
     }
 
     .login-logo-container {
-      width: 6rem; /* reduce size for better fit */
-      height: 6rem;
+      width: 7rem; /* slightly larger for better visibility */
+      height: 7rem;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -2416,21 +2417,21 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     }
 
     .login-bank-logo-container {
-      width: 6rem;
-      height: 6rem;
+      width: 7rem;
+      height: 7rem;
       display: flex;
       align-items: center;
       justify-content: center;
     }
 
     .login-logo img {
-      height: 6rem;
+      height: 7rem;
       width: auto;
       object-fit: contain;
     }
 
     .login-bank-logo-container img {
-      height: 6rem;
+      height: 7rem;
       width: auto;
       object-fit: contain;
     }


### PR DESCRIPTION
## Summary
- enlarge login bank and Remeex Visa logos in `recarga.html`
- center the logos and reduce spacing so that they appear closer together

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876abe583688324bab8caff120b32b3