### PR TITLE
Fix verification progress after document upload

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -10072,6 +10072,9 @@ function playVerificationProgressSound() {
       updateWhatsAppLinks();
 
       updateVerificationButtons();
+
+      // Verificar si se reanudó un proceso de verificación de documentos
+      checkVerificationProcessingStatus();
     }
 
     // Cargar credenciales del usuario desde localStorage

--- a/public/verificacion.html
+++ b/public/verificacion.html
@@ -3706,10 +3706,12 @@
     function redirectToDashboard() {
         const targetUrl = 'recarga.html';
       if (window.opener && !window.opener.closed) {
-        window.opener.location.href = targetUrl;
+        // Forzar recarga completa para asegurar que se inicie el proceso de
+        // verificación en la página principal
+        window.opener.location.href = `${targetUrl}?reload=${Date.now()}`;
         window.close();
       } else {
-        window.location.href = targetUrl;
+        window.location.href = `${targetUrl}?reload=${Date.now()}`;
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure opener page reloads after redirect from document verification
- resume verification progress check on app init

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687791c700d883249d0042a3795f673f