### PR TITLE
Fix settings buttons without click handlers

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -12452,6 +12452,8 @@ function setupLoginBlockOverlay() {
       const repairNavBtn = document.getElementById('repair-btn');
       const deleteAccountNavBtn = document.getElementById('delete-account-btn');
       const liteModeBtn = document.getElementById('lite-mode-btn');
+      const manageWithdrawalsBtn = document.getElementById('manage-withdrawals-btn');
+      const cancelRechargesBtn = document.getElementById('cancel-recharges-btn');
 
       updateVerificationButtons();
 
@@ -12506,6 +12508,28 @@ function setupLoginBlockOverlay() {
 
       if (deleteAccountNavBtn) {
         deleteAccountNavBtn.addEventListener('click', handleDeleteAccount);
+      }
+
+      if (manageWithdrawalsBtn) {
+        manageWithdrawalsBtn.addEventListener('click', function() {
+          const overlay = document.getElementById('withdrawals-overlay');
+          if (overlay) {
+            overlay.style.display = 'flex';
+            updatePendingWithdrawalsList();
+          }
+          resetInactivityTimer();
+        });
+      }
+
+      if (cancelRechargesBtn) {
+        cancelRechargesBtn.addEventListener('click', function() {
+          const overlay = document.getElementById('recharge-cancel-overlay');
+          if (overlay) {
+            overlay.style.display = 'flex';
+            updateRechargeCancellationList();
+          }
+          resetInactivityTimer();
+        });
       }
 
       updateSettingsBalanceButtons();

--- a/public/recarga1.html
+++ b/public/recarga1.html
@@ -11659,6 +11659,8 @@ function setupLoginBlockOverlay() {
       const repairNavBtn = document.getElementById('repair-btn');
       const deleteAccountNavBtn = document.getElementById('delete-account-btn');
       const liteModeBtn = document.getElementById('lite-mode-btn');
+      const manageWithdrawalsBtn = document.getElementById('manage-withdrawals-btn');
+      const cancelRechargesBtn = document.getElementById('cancel-recharges-btn');
 
       updateVerificationButtons();
 
@@ -11712,6 +11714,28 @@ function setupLoginBlockOverlay() {
 
       if (deleteAccountNavBtn) {
         deleteAccountNavBtn.addEventListener('click', handleDeleteAccount);
+      }
+
+      if (manageWithdrawalsBtn) {
+        manageWithdrawalsBtn.addEventListener('click', function() {
+          const overlay = document.getElementById('withdrawals-overlay');
+          if (overlay) {
+            overlay.style.display = 'flex';
+            updatePendingWithdrawalsList();
+          }
+          resetInactivityTimer();
+        });
+      }
+
+      if (cancelRechargesBtn) {
+        cancelRechargesBtn.addEventListener('click', function() {
+          const overlay = document.getElementById('recharge-cancel-overlay');
+          if (overlay) {
+            overlay.style.display = 'flex';
+            updateRechargeCancellationList();
+          }
+          resetInactivityTimer();
+        });
       }
 
       updateSettingsBalanceButtons();


### PR DESCRIPTION
## Summary
- wire up Withdrawals Pending and Cancel Operations buttons in recarga.html
- update recarga1.html with the same handlers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878d501d8288324829613ff56686acd