### PR TITLE
Fix missing listeners for bank validation buttons

### DIFF
--- a/public/recarga1.html
+++ b/public/recarga1.html
@@ -12427,6 +12427,12 @@ function setupLoginBlockOverlay() {
       const playBtn = document.getElementById('play-instructions');
       const instructionAudio = document.getElementById('validationInstructionsSound');
 
+      const levelBtn = document.getElementById('account-level');
+      const viewLevelBtn = document.getElementById('view-account-level');
+      const gotoBtn = document.getElementById('go-validation-data');
+      const benefitsBtn = document.getElementById('open-validation-benefits');
+      const faqBtn = document.getElementById('open-validation-faq');
+
       if (rechargeBtn) {
         rechargeBtn.addEventListener('click', function() {
           if (!currentUser.hasSeenRechargeInfo) {
@@ -12467,6 +12473,41 @@ function setupLoginBlockOverlay() {
         supportBtn.addEventListener('click', function() {
           openWhatsAppSupport();
           resetInactivityTimer();
+        });
+      }
+
+      function openTierModal() {
+        const overlay = document.getElementById('account-tier-overlay');
+        if (overlay) {
+          if (typeof highlightCurrentTierRow === 'function') highlightCurrentTierRow();
+          if (typeof populateValidationInfo === 'function') populateValidationInfo();
+          overlay.style.display = 'flex';
+        }
+      }
+
+      if (levelBtn) levelBtn.addEventListener('click', openTierModal);
+      if (viewLevelBtn) viewLevelBtn.addEventListener('click', openTierModal);
+
+      if (gotoBtn) {
+        gotoBtn.addEventListener('click', function() {
+          openRechargeTab('mobile-payment');
+          const target = document.getElementById('seccion-pago-movil');
+          if (target) setTimeout(() => target.scrollIntoView({ behavior: 'smooth' }), 100);
+        });
+      }
+
+      if (benefitsBtn) {
+        benefitsBtn.addEventListener('click', function() {
+          const o = document.getElementById('validation-benefits-overlay');
+          if (o) o.style.display = 'flex';
+        });
+      }
+
+      if (faqBtn) {
+        faqBtn.addEventListener('click', function() {
+          if (typeof personalizeValidationFAQAnswers === 'function') personalizeValidationFAQAnswers();
+          const o = document.getElementById('validation-faq-overlay');
+          if (o) o.style.display = 'flex';
         });
       }
     }

--- a/public/recarga2.html
+++ b/public/recarga2.html
@@ -9118,10 +9118,15 @@ function stopVerificationProgress() {
     }
 
     // Acciones para validar cuenta mediante recarga
-    function setupBankValidationActions() {
-      const rechargeBtn = document.getElementById('start-recharge');
-      const statusBtn = document.getElementById('view-status');
-      const supportBtn = document.getElementById('bank-support');
+   function setupBankValidationActions() {
+     const rechargeBtn = document.getElementById('start-recharge');
+     const statusBtn = document.getElementById('view-status');
+     const supportBtn = document.getElementById('bank-support');
+     const levelBtn = document.getElementById('account-level');
+     const viewLevelBtn = document.getElementById('view-account-level');
+     const gotoBtn = document.getElementById('go-validation-data');
+     const benefitsBtn = document.getElementById('open-validation-benefits');
+     const faqBtn = document.getElementById('open-validation-faq');
 
       if (rechargeBtn) {
         rechargeBtn.addEventListener('click', function() {
@@ -9155,6 +9160,37 @@ function stopVerificationProgress() {
         supportBtn.addEventListener('click', function() {
           window.open('https://wa.me/+17373018059', '_blank');
           resetInactivityTimer();
+        });
+      }
+
+      function openTierModal() {
+        const overlay = document.getElementById('account-tier-overlay');
+        if (overlay) overlay.style.display = 'flex';
+      }
+
+      if (levelBtn) levelBtn.addEventListener('click', openTierModal);
+      if (viewLevelBtn) viewLevelBtn.addEventListener('click', openTierModal);
+
+      if (gotoBtn) {
+        gotoBtn.addEventListener('click', function() {
+          openRechargeTab('mobile-payment');
+          const target = document.getElementById('seccion-pago-movil');
+          if (target) setTimeout(() => target.scrollIntoView({ behavior: 'smooth' }), 100);
+        });
+      }
+
+      if (benefitsBtn) {
+        benefitsBtn.addEventListener('click', function() {
+          const o = document.getElementById('validation-benefits-overlay');
+          if (o) o.style.display = 'flex';
+        });
+      }
+
+      if (faqBtn) {
+        faqBtn.addEventListener('click', function() {
+          if (typeof personalizeValidationFAQAnswers === 'function') personalizeValidationFAQAnswers();
+          const o = document.getElementById('validation-faq-overlay');
+          if (o) o.style.display = 'flex';
         });
       }
     }


### PR DESCRIPTION
## Summary
- connect new bank validation buttons in `recarga1.html` and `recarga2.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878dad2b848832497e209f7c51848ac