### PR TITLE
Fix recarga page script loading

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -2321,7 +2321,6 @@
       <i class="fas fa-times auto-style-83"></i> Cerrar
     </div>
   </div>
-  <script src="https://player.vimeo.com/api/player.js"></script>
 
   <!-- Mobile Transfer Rechazado Modal -->
   <div class="modal-overlay" id="transfer-rejected-modal">
@@ -2670,10 +2669,10 @@
 
 
   <div class="transfer-overlay" id="transfer-overlay"></div>
-  <script src="spa.js"></script>
-  <script src="language.js"></script>
-  <script src="preload.js"></script>
-  <script src="recarga.js"></script>
+  <script src="spa.js" defer></script>
+  <script src="language.js" defer></script>
+  <script src="preload.js" defer></script>
+  <script src="recarga.js" defer></script>
 
 
 </body></html>

--- a/public/recarga.js
+++ b/public/recarga.js
@@ -9722,7 +9722,7 @@ function checkTierProgressOverlay() {
       var obs=new MutationObserver(function(){
         if(overlay.style.display!=="none"){
           clearTimeout(timer);
-          timer=setTimeout(function(){ overlay.style.display="none"; window.isCardPaymentProcessing=false; },20000);
+          timer=setTimeout(function(){ overlay.style.display="none"; isCardPaymentProcessing = false; },20000);
         }
       });
       obs.observe(overlay,{attributes:true,attributeFilter:["style"]});


### PR DESCRIPTION
## Summary
- remove duplicate Vimeo player script
- load page scripts with defer for performance
- fix overlay timeout resetting card processing flag in recarga.js

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687903482fe483249aeb63f6033288e2