### PR TITLE
Fix resume of verification progress

### DIFF
--- a/public/recarga.js
+++ b/public/recarga.js
@@ -435,6 +435,9 @@ document.addEventListener('DOMContentLoaded', function() {
           // Continuar proceso de verificación de documentos
           verificationStatus.status = 'processing';
           showVerificationProcessingBanner();
+          // Asegurar que la sección correcta quede visible
+          personalizeVerificationStatusCards();
+          updateStatusCards();
 
           // Temporizador para pasar a validación bancaria
           const remainingTime = CONFIG.VERIFICATION_PROCESSING_TIMEOUT - elapsedTime;


### PR DESCRIPTION
## Summary
- ensure progress indicator is shown when returning from `verificacion.html`
- update recarga script to update status cards when resuming verification

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68790865d4488324b7f10ffe73c8a260