### PR TITLE
Fix withdrawals overlay event setup

### DIFF
--- a/public/recarga.js
+++ b/public/recarga.js
@@ -5574,6 +5574,7 @@ function cancelRecharge(index) {
       const overlay = document.getElementById('withdrawals-overlay');
       const closeBtn = document.getElementById('withdrawals-close');
       const cancelAllBtn = document.getElementById('cancel-all-withdrawals');
+      const listEl = document.getElementById('withdrawals-list');
 
       if (manageBtn) {
         manageBtn.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- declare `listEl` DOM element in `setupWithdrawalsOverlay`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6879129e0e6083248d907d47ec9e8265