### PR TITLE
Fix module-scoped functions not exposed

### DIFF
--- a/public/recargamain.js
+++ b/public/recargamain.js
@@ -9485,3 +9485,8 @@ function checkTierProgressOverlay() {
       });
       obs.observe(overlay,{attributes:true,attributeFilter:["style"]});
     });
+
+    // Expose functions used by inline event handlers
+    window.toggleValidationMore = toggleValidationMore;
+    window.toggleWithdrawals = toggleWithdrawals;
+    window.openRechargeTab = openRechargeTab;


### PR DESCRIPTION
## Summary
- attach several functions from recargamain.js to `window`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879657c05a88324928acb510859fbd0