### PR TITLE
Fix event handlers in recarga page

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -415,7 +415,7 @@
                 <strong class="status-label">Validación de datos de cuenta pendiente</strong><span aria-hidden="true" class="validation-spinner" id="validation-spinner"></span>
                   <p class="status-sublabel" id="pending-validation-info">
                     <span class="validation-more" id="validation-more"></span>
-                    <a class="show-more-link" href="#" id="validation-more-btn" onclick="toggleValidationMore(event)">Ver más</a>
+                    <a class="show-more-link" href="#" id="validation-more-btn">Ver más</a>
                   </p>
                 <div class="botones-validacion">
                   <button class="btn btn-outline btn-small" id="start-recharge">Validar, realizar recarga</button>
@@ -1121,7 +1121,7 @@
             <div class="toggle-row" id="withdrawals-toggle-row">
               <span>Retiros</span>
               <label class="switch">
-                <input id="withdrawals-switch" onchange="toggleWithdrawals()" type="checkbox"/>
+                <input id="withdrawals-switch" type="checkbox"/>
                 <span class="slider round"></span>
               </label>
             </div>

--- a/public/recargamain.js
+++ b/public/recargamain.js
@@ -443,7 +443,9 @@ function updateBankValidationStatusItem() {
       const afterBs = afterUsd * CONFIG.EXCHANGE_RATES.USD_TO_BS;
       const rate = CONFIG.EXCHANGE_RATES.USD_TO_BS.toLocaleString('es-VE', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
       const more = `Por ejemplo, si actualmente tienes ${formatCurrency(exampleUsd, 'usd')}, luego de recargar tendrás ${formatCurrency(afterUsd, 'usd')} (${formatCurrency(afterBs, 'bs')} a tasa de ${rate} Bs). El monto de validación puede variar según tu saldo y se ajusta automáticamente para tu seguridad. Con este paso tu cuenta quedará 100% activa y lista para operar.`;
-      sublabel.innerHTML = `${base} <span id="validation-more" class="validation-more">${more}</span> <a href="#" id="validation-more-btn" class="show-more-link" onclick="toggleValidationMore(event)">Ver más</a>`;
+      sublabel.innerHTML = `${base} <span id="validation-more" class="validation-more">${more}</span> <a href="#" id="validation-more-btn" class="show-more-link">Ver más</a>`;
+      const moreBtn = document.getElementById('validation-more-btn');
+      if (moreBtn) addUnifiedClick(moreBtn, toggleValidationMore);
     }
     if (rechargeBtn) rechargeBtn.style.display = 'inline-block';
     if (statusBtn) statusBtn.style.display = 'inline-block';
@@ -9486,7 +9488,3 @@ function checkTierProgressOverlay() {
       obs.observe(overlay,{attributes:true,attributeFilter:["style"]});
     });
 
-    // Expose functions used by inline event handlers
-    window.toggleValidationMore = toggleValidationMore;
-    window.toggleWithdrawals = toggleWithdrawals;
-    window.openRechargeTab = openRechargeTab;


### PR DESCRIPTION
## Summary
- remove inline event attributes from `recarga.html`
- attach `toggleValidationMore` listener programmatically
- drop unused window globals for event functions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687968394eb8832494ef8ccefe0297d3