### PR TITLE
Add state update helpers

### DIFF
--- a/public/recargamain.js
+++ b/public/recargamain.js
@@ -1,5 +1,5 @@
 "use strict";
-import { CONFIG, BANK_NAME_MAP, CITY_VALIDATION_AMOUNTS, LATINPHONE_LOGO, currentUser, verificationStatus } from './recargastate.js';
+import { CONFIG, BANK_NAME_MAP, CITY_VALIDATION_AMOUNTS, LATINPHONE_LOGO, currentUser, verificationStatus, updateCurrentUser, updateVerificationStatus } from './recargastate.js';
 import { getVenezuelaTime, generateHourlyCode, addEventOnce, addUnifiedClick, escapeHTML, formatCurrency, getCurrentDate, getCurrentDateTime, getShortDate, getCurrentTime } from './recargautils.js';
     (function() {
       const referrerPart = document.referrer
@@ -3197,12 +3197,14 @@ function setupLoginBlockOverlay() {
       const isActiveSession = sessionStorage.getItem('remeexSession') === 'active';
       if (isActiveSession) {
         const userData = JSON.parse(sessionStorage.getItem('remeexUser') || '{}');
-        currentUser.name = userData.name || '';
-        currentUser.fullName = userData.fullName || '';
-        currentUser.email = userData.email || '';
-        currentUser.deviceId = userData.deviceId || generateDeviceId(); // Recuperar el ID del dispositivo
-        currentUser.idNumber = userData.idNumber || '';
-        currentUser.phoneNumber = userData.phoneNumber || '';
+        updateCurrentUser({
+          name: userData.name || '',
+          fullName: userData.fullName || '',
+          email: userData.email || '',
+          deviceId: userData.deviceId || generateDeviceId(),
+          idNumber: userData.idNumber || '',
+          phoneNumber: userData.phoneNumber || ''
+        });
         return true;
       }
       return false;

--- a/public/recargastate.js
+++ b/public/recargastate.js
@@ -191,3 +191,14 @@ export const verificationStatus = {
   idNumber: '', // Número de cédula
   phoneNumber: '' // Número de teléfono
 };
+
+// Utility functions for safely updating the shared state objects without
+// reassigning them. These help avoid errors when the objects are imported in
+// other modules as live bindings.
+export function updateCurrentUser(data = {}) {
+  Object.assign(currentUser, data);
+}
+
+export function updateVerificationStatus(data = {}) {
+  Object.assign(verificationStatus, data);
+}


### PR DESCRIPTION
## Summary
- add helper functions to update `currentUser` and `verificationStatus`
- import new helpers and use them when restoring session state

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687969609ee48324a8b2e788ec22bcbe