### PR TITLE
Load admin credentials via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ Este repositorio contiene una aplicación sencilla de ejemplo. Ahora incluye un 
    Ahora también expone las páginas estáticas del directorio `public`.
    Si accedes a una ruta con terminación `.html` serás redirigido
    automáticamente a la versión sin extensión, por ejemplo
-   `/recarga.html` redirige a `/recarga`.
+
+### Variables de entorno
+
+Antes de iniciar el servidor debes definir las siguientes variables:
+
+- `ADMIN_USERNAME` – nombre de usuario permitido para acceder al panel de administración.
+- `ADMIN_PASSWORD` – contraseña correspondiente a ese usuario.
 
 ### Endpoints principales
 

--- a/api/admin.js
+++ b/api/admin.js
@@ -10,8 +10,7 @@ let users = [
   { id: 2, username: 'bob', password: 'bob456', balance: 200 }
 ];
 
-const ADMIN_USERNAME = 'admin';
-const ADMIN_PASSWORD = 'adminpass';
+const { ADMIN_USERNAME, ADMIN_PASSWORD } = process.env;
 let sessionToken = null;
 
 function auth(req, res, next) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -25,8 +25,7 @@ let users = [
   { id: 2, username: 'bob', password: 'bob456', balance: 200 }
 ];
 
-const ADMIN_USERNAME = 'admin';
-const ADMIN_PASSWORD = 'adminpass';
+const { ADMIN_USERNAME, ADMIN_PASSWORD } = process.env;
 let sessionToken = null;
 
 function auth(req, res, next) {


### PR DESCRIPTION
## Summary
- read `ADMIN_USERNAME` and `ADMIN_PASSWORD` from environment variables in both server implementations
- document the required environment variables

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a0a96bf94832491c68d707a42d7fe