### PR TITLE
Adjust balance flow cards for small screens

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -3554,6 +3554,21 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       50% { transform: translateX(8px); opacity: 1; }
     }
 
+    /* Ajustes para mostrar el flujo de balance en una sola fila en pantallas
+       pequeñas */
+    @media (max-width: 480px) {
+      .balance-flow-logos { flex-wrap: nowrap; gap: 0.5rem; }
+      .balance-flow .balance-card {
+        width: 60px;
+        height: 90px;
+        padding: 0.5rem;
+      }
+      .balance-flow .bank-logo-mini { height: 18px; }
+      .balance-flow .balance-amount { font-size: 0.75rem; }
+      .balance-label { font-size: 0.65rem; }
+      .flow-operator { font-size: 1.2rem; }
+    }
+
 
     /* Receipt Upload */
     .receipt-upload {


### PR DESCRIPTION
## Summary
- update CSS in `recarga.html` so balance flow cards stay in a single row on small devices

## Testing
- `npm test` *(fails: expected 200 OK, got 401)*

------
https://chatgpt.com/codex/tasks/task_e_687a1c95b64c83249f2f602a437ee9f1