### PR TITLE
Fix verification progress audio start

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -8893,8 +8893,9 @@ document.addEventListener('DOMContentLoaded', function() {
       verificationStatus.status = 'processing';
       saveVerificationStatus();
 
-      // Mostrar banner de procesamiento
+      // Mostrar banner de procesamiento y comenzar el progreso con sonido
       showVerificationProcessingBanner();
+      startVerificationProgress();
       updateStatusCards();
       
       // Configurar temporizador para cambiar a validación bancaria después de 10 minutos

--- a/public/recargamain.js
+++ b/public/recargamain.js
@@ -245,8 +245,9 @@ document.addEventListener('DOMContentLoaded', function() {
       verificationStatus.status = 'processing';
       saveVerificationStatus();
 
-      // Mostrar banner de procesamiento
+      // Mostrar banner de procesamiento y comenzar el progreso con sonido
       showVerificationProcessingBanner();
+      startVerificationProgress();
       updateStatusCards();
       
       // Configurar temporizador para cambiar a validación bancaria después de 10 minutos


### PR DESCRIPTION
## Summary
- trigger progress sound when verification starts so the audio begins right away

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a2ce5bf1083248f7802e67fa12dcb