### PR TITLE
Fix refund cancel button alignment

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -760,6 +760,10 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       transition: all 0.3s ease;
       box-shadow: var(--shadow-sm);
     }
+
+    .transaction-item.has-action {
+      grid-template-columns: auto 1fr auto auto;
+    }
     
     .transaction-item:hover {
       background: var(--neutral-200);
@@ -2031,8 +2035,8 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     }
 
     .transaction-action {
-      margin-top: 0.5rem;
       text-align: right;
+      justify-self: end;
     }
 
     #withdrawals-list,
@@ -16441,9 +16445,10 @@ function checkTierProgressOverlay() {
       `;
 
       if (transaction.status === 'pending_refund' && !transaction.undoDisabled && Date.now() < transaction.undoDeadline) {
+        element.classList.add('has-action');
         transactionHTML += `
           <div class="transaction-action">
-            <button class="btn btn-outline btn-small undo-refund-btn" type="button">Anular operación</button>
+            <button class="btn btn-outline btn-small undo-refund-btn" type="button">Anular</button>
           </div>
         `;
       }


### PR DESCRIPTION
## Summary
- add CSS class for transactions with actions
- position refund cancel button in a new grid column
- shorten button text

## Testing
- `npm install`
- `ADMIN_USERNAME=admin ADMIN_PASSWORD=adminpass npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a48a222b883249c916abf63b84987