### PR TITLE
Add user creation endpoint and admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ la ruta `/api`. Los principales endpoints son:
 
 - `POST /api/admin/login` – recibe `username` y `password` y devuelve un token de sesión.
 - `GET /api/admin/users` – requiere el token en el encabezado `Authorization` y lista los usuarios conectados con su nombre y saldo.
+- `POST /api/admin/users` – crea un nuevo usuario (requiere token).
 - `PUT /api/admin/users/:id/password` – permite actualizar la clave de un usuario (requiere token).
 - `GET /api/admin/users/:id` – devuelve todos los detalles de un usuario específico (requiere token).
 - `DELETE /api/admin/users/:id` – elimina un usuario de la lista (requiere token).
@@ -45,6 +46,7 @@ Desde esta página podrás:
 
 - Iniciar sesión como administrador a través de `POST /api/admin/login`.
 - Consultar los usuarios conectados mediante `GET /api/admin/users`.
+- Crear nuevos usuarios con `POST /api/admin/users`.
 - Actualizar la clave de cualquier usuario usando `PUT /api/admin/users/:id/password`.
 - Ver los detalles de un usuario con `GET /api/admin/users/:id`.
 - Eliminar usuarios mediante `DELETE /api/admin/users/:id`.

--- a/api/admin.js
+++ b/api/admin.js
@@ -62,4 +62,15 @@ app.delete('/admin/users/:id', auth, (req, res) => {
   res.status(404).json({ error: 'Usuario no encontrado' });
 });
 
+app.post('/admin/users', auth, (req, res) => {
+  const { username, password, balance } = req.body;
+  if (username && password && balance !== undefined) {
+    const id = users.length ? Math.max(...users.map(u => u.id)) + 1 : 1;
+    const newUser = { id, username, password, balance: Number(balance) };
+    users.push(newUser);
+    return res.status(201).json(newUser);
+  }
+  res.status(400).json({ error: 'Datos inválidos' });
+});
+
 export default app;

--- a/backend/server.js
+++ b/backend/server.js
@@ -77,6 +77,17 @@ app.delete('/admin/users/:id', auth, (req, res) => {
   res.status(404).json({ error: 'Usuario no encontrado' });
 });
 
+app.post('/admin/users', auth, (req, res) => {
+  const { username, password, balance } = req.body;
+  if (username && password && balance !== undefined) {
+    const id = users.length ? Math.max(...users.map(u => u.id)) + 1 : 1;
+    const newUser = { id, username, password, balance: Number(balance) };
+    users.push(newUser);
+    return res.status(201).json(newUser);
+  }
+  res.status(400).json({ error: 'Datos inválidos' });
+});
+
 if (process.env.NODE_ENV !== 'test') {
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/public/admin.html
+++ b/public/admin.html
@@ -64,6 +64,16 @@
       </div>
       <div id="updateMsg" class="success" style="display:none;"></div>
     </section>
+    <section style="margin-top:1.5rem;">
+      <h2>Crear Usuario</h2>
+      <div class="password-update">
+        <input id="newUsername" type="text" placeholder="Usuario">
+        <input id="newUserPass" type="text" placeholder="Contraseña">
+        <input id="newUserBalance" type="number" placeholder="Saldo">
+        <button id="createBtn" style="width:auto; padding:0 1rem;">Crear</button>
+      </div>
+      <div id="createMsg" class="success" style="display:none;"></div>
+    </section>
   </div>
 
   <script>
@@ -136,6 +146,34 @@
         loadUsers();
       } else {
         msg.textContent = 'Error al actualizar';
+        msg.style.display = 'block';
+        msg.className = 'error';
+      }
+    });
+
+    document.getElementById('createBtn').addEventListener('click', async () => {
+      const username = document.getElementById('newUsername').value.trim();
+      const password = document.getElementById('newUserPass').value.trim();
+      const balance = document.getElementById('newUserBalance').value;
+      const res = await fetch('/api/admin/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + token
+        },
+        body: JSON.stringify({ username, password, balance })
+      });
+      const msg = document.getElementById('createMsg');
+      if (res.ok) {
+        msg.textContent = 'Usuario creado';
+        msg.style.display = 'block';
+        msg.className = 'success';
+        document.getElementById('newUsername').value = '';
+        document.getElementById('newUserPass').value = '';
+        document.getElementById('newUserBalance').value = '';
+        loadUsers();
+      } else {
+        msg.textContent = 'Error al crear';
         msg.style.display = 'block';
         msg.className = 'error';
       }

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -28,6 +28,15 @@ describe('Admin API', () => {
     expect(Array.isArray(res.body.users)).toBe(true);
   });
 
+  it('creates a user', async () => {
+    const res = await request(app)
+      .post('/admin/users')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ username: 'charlie', password: 'charlie789', balance: 300 });
+    expect(res.status).toBe(201);
+    expect(res.body.username).toBe('charlie');
+  });
+
   it('updates and retrieves a user password', async () => {
     await request(app)
       .put('/admin/users/1/password')

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -21,4 +21,18 @@ describe('Backend server', () => {
     expect(users.status).toBe(200);
     expect(Array.isArray(users.body.users)).toBe(true);
   });
+
+  it('creates a user via the API', async () => {
+    const login = await request(app)
+      .post('/admin/login')
+      .send({ username: 'admin', password: 'adminpass' });
+    const token = login.body.token;
+
+    const res = await request(app)
+      .post('/admin/users')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ username: 'dave', password: 'dave123', balance: 50 });
+    expect(res.status).toBe(201);
+    expect(res.body.username).toBe('dave');
+  });
 });


### PR DESCRIPTION
## Summary
- extend README instructions with new user creation endpoint
- support creating users in API and server
- allow admin interface to create users
- test user creation via server and API

## Testing
- `ADMIN_USERNAME=admin ADMIN_PASSWORD=adminpass npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aa857de9c8324bda51e7f5d039fd9