### PR TITLE
Add user session tracking and connected users endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ la ruta `/api`. Los principales endpoints son:
 - `POST /api/admin/login` – recibe `username` y `password` y devuelve un token de sesión.
 - `GET /api/admin/users` – requiere el token en el encabezado `Authorization` y lista los usuarios conectados con su nombre y saldo.
 - `POST /api/admin/users` – crea un nuevo usuario (requiere token).
+- `GET /api/admin/connected` – muestra cuántos usuarios tienen una sesión
+  activa y sus detalles (requiere token).
 - `PUT /api/admin/users/:id/password` – permite actualizar la clave de un usuario (requiere token).
 - `GET /api/admin/users/:id` – devuelve todos los detalles de un usuario específico (requiere token).
 - `DELETE /api/admin/users/:id` – elimina un usuario de la lista (requiere token).
+- `POST /api/login` – inicia sesión de usuario y registra la hora de conexión.
+- `POST /api/logout` – cierra la sesión del usuario especificado.
 
 Estos datos se almacenan en memoria para fines de demostración.
 

--- a/api/admin.js
+++ b/api/admin.js
@@ -4,10 +4,24 @@ import bodyParser from 'body-parser';
 const app = express();
 app.use(bodyParser.json());
 
-// Simple in-memory user store
+// Simple in-memory user store with session tracking
 let users = [
-  { id: 1, username: 'alice', password: 'alice123', balance: 100 },
-  { id: 2, username: 'bob', password: 'bob456', balance: 200 }
+  {
+    id: 1,
+    username: 'alice',
+    password: 'alice123',
+    balance: 100,
+    phase: 'desconectado',
+    sessions: []
+  },
+  {
+    id: 2,
+    username: 'bob',
+    password: 'bob456',
+    balance: 200,
+    phase: 'desconectado',
+    sessions: []
+  }
 ];
 
 const { ADMIN_USERNAME, ADMIN_PASSWORD } = process.env;
@@ -33,6 +47,11 @@ app.post('/admin/login', (req, res) => {
 
 app.get('/admin/users', auth, (req, res) => {
   res.json({ users });
+});
+
+app.get('/admin/connected', auth, (req, res) => {
+  const connectedUsers = users.filter(u => u.sessions.some(s => !s.logout));
+  res.json({ connected: connectedUsers.length, users: connectedUsers });
 });
 
 app.get('/admin/users/:id', auth, (req, res) => {
@@ -66,11 +85,44 @@ app.post('/admin/users', auth, (req, res) => {
   const { username, password, balance } = req.body;
   if (username && password && balance !== undefined) {
     const id = users.length ? Math.max(...users.map(u => u.id)) + 1 : 1;
-    const newUser = { id, username, password, balance: Number(balance) };
+    const newUser = {
+      id,
+      username,
+      password,
+      balance: Number(balance),
+      phase: 'desconectado',
+      sessions: []
+    };
     users.push(newUser);
     return res.status(201).json(newUser);
   }
   res.status(400).json({ error: 'Datos inválidos' });
+});
+
+// --- Public user session endpoints ---
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username && u.password === password);
+  if (!user) {
+    return res.status(401).json({ error: 'Credenciales inválidas' });
+  }
+  user.sessions.push({ login: Date.now(), logout: null });
+  user.phase = 'activo';
+  res.json({ id: user.id });
+});
+
+app.post('/logout', (req, res) => {
+  const { id } = req.body;
+  const user = users.find(u => u.id === Number(id));
+  if (!user) {
+    return res.status(404).json({ error: 'Usuario no encontrado' });
+  }
+  const session = user.sessions[user.sessions.length - 1];
+  if (session && !session.logout) {
+    session.logout = Date.now();
+  }
+  user.phase = 'desconectado';
+  res.json({ success: true });
 });
 
 export default app;


### PR DESCRIPTION
## Summary
- track login sessions and current phase for each user
- expose `/admin/connected` to list active sessions
- add public `/login` and `/logout` endpoints
- document the new endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aaae423b88324a2fcf4afc747a37e