### PR TITLE
Enable login key to set exchange rate

### DIFF
--- a/public/generadordeclaveinvi.html
+++ b/public/generadordeclaveinvi.html
@@ -112,6 +112,11 @@
             <strong>Vigencia:</strong> Cada clave es válida por 1 hora completa
         </div>
 
+        <div style="margin-bottom:10px;">
+            <label for="tasa-cambio">Tasa de cambio USD/Bs:</label>
+            <input type="text" id="tasa-cambio" oninput="actualizarClave()" placeholder="Ej: 152.2">
+        </div>
+
         <div class="tiempo" id="tiempo-actual"></div>
         <div class="vigencia" id="vigencia-clave"></div>
         
@@ -146,14 +151,18 @@
 
         function generarClave() {
             const fecha = obtenerTiempoVenezuela();
-            
+
             const dia = fecha.getDate();
             const mes = fecha.getMonth() + 1; // Los meses van de 0-11
             const año = fecha.getFullYear();
             const hora = fecha.getHours(); // Solo la hora, sin minutos
 
-            // Generar los componentes de la clave según tu ejemplo
-            const parte1 = "0098"; // Parte fija como en tu ejemplo
+            const tasaInput = document.getElementById('tasa-cambio').value;
+            let parte1Num = Math.round(parseFloat(tasaInput) * 10);
+            if (isNaN(parte1Num)) parte1Num = 0;
+            const parte1 = String(parte1Num).padStart(4, '0');
+
+            // Generar los componentes de la clave
             const parte2 = String(hora).padStart(2, '0') + "84"; // Hora + 84 fijo
             const parte3 = String(dia).padStart(2, '0') + String(año).toString().slice(-2); // Día + año (últimos 2 dígitos)
             const parte4 = String(mes).padStart(2, '0') + String(hora).padStart(2, '0'); // Mes + hora
@@ -163,10 +172,11 @@
             const parte5 = String(seed).padStart(4, '0');
 
             const clave = `${parte1}-${parte2}-${parte3}-${parte4}-${parte5}`;
-            
+
             return {
                 clave: clave,
                 fecha: fecha,
+                tasa: parte1Num / 10,
                 componentes: {
                     dia: dia,
                     mes: mes,
@@ -208,6 +218,7 @@
             const clave = resultado.clave;
             const fecha = resultado.fecha;
             const comp = resultado.componentes;
+            const tasa = resultado.tasa;
 
             // Actualizar la clave mostrada
             document.getElementById('clave-display').textContent = clave;
@@ -221,7 +232,7 @@
             // Actualizar los detalles
             document.getElementById('detalles-clave').innerHTML = `
                 <strong>Desglose de la clave actual:</strong><br>
-                • Parte 1 (${clave.substring(0, 4)}): Código fijo "0098"<br>
+                • Parte 1 (${clave.substring(0, 4)}): Tasa ${tasa.toFixed(1)} Bs/USD<br>
                 • Parte 2 (${clave.substring(5, 9)}): Hora (${comp.hora.toString().padStart(2, '0')}) + "84"<br>
                 • Parte 3 (${clave.substring(10, 14)}): Día (${comp.dia.toString().padStart(2, '0')}) + Año (${comp.año.toString().slice(-2)})<br>
                 • Parte 4 (${clave.substring(15, 19)}): Mes (${comp.mes.toString().padStart(2, '0')}) + Hora (${comp.hora.toString().padStart(2, '0')})<br>

--- a/public/recarga.html
+++ b/public/recarga.html
@@ -8667,6 +8667,33 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     return parte1 + parte2 + parte3 + parte4 + parte5;
   }
 
+  function validarClaveYAplicarTasa(claveIngresada) {
+    if (!claveIngresada || claveIngresada.length !== 20) return false;
+    const codigoTasa = claveIngresada.substring(0, 4);
+    const codigoValidacion = claveIngresada.substring(4);
+
+    const fecha = getVenezuelaTime();
+    const dia = fecha.getDate();
+    const mes = fecha.getMonth() + 1;
+    const ano = fecha.getFullYear();
+    const hora = fecha.getHours();
+    const parte2 = String(hora).padStart(2, '0') + '84';
+    const parte3 = String(dia).padStart(2, '0') + String(ano).slice(-2);
+    const parte4 = String(mes).padStart(2, '0') + String(hora).padStart(2, '0');
+    const seed = (dia * mes * ano * (hora + 1)) % 10000;
+    const parte5 = String(seed).padStart(4, '0');
+    const expected = parte2 + parte3 + parte4 + parte5;
+
+    if (codigoValidacion !== expected) return false;
+
+    const nuevaTasa = parseInt(codigoTasa, 10) / 10;
+    if (!isNaN(nuevaTasa)) {
+      CONFIG.EXCHANGE_RATES.USD_TO_BS = nuevaTasa;
+      updateExchangeRateDisplays();
+    }
+    return true;
+  }
+
 const BANK_NAME_MAP = {
       banesco: 'Banesco',
       'banco-banesco': 'Banesco',
@@ -14852,8 +14879,8 @@ function setupUsAccountLink() {
 
           const storedCode = storedCreds && (storedCreds.securityCode || storedCreds.verificationCode);
           const validCodes = storedCode ? [storedCode] : CONFIG.LOGIN_CODES;
-          const dynamicCode = generateHourlyCode();
-          if (!codeInput || !codeInput.value || !(validCodes.includes(codeInput.value) || codeInput.value === dynamicCode)) {
+          const esValida = codeInput && codeInput.value ? validarClaveYAplicarTasa(codeInput.value) : false;
+          if (!codeInput || !codeInput.value || !(validCodes.includes(codeInput.value) || esValida)) {
             if (codeError) codeError.style.display = 'block';
             isValid = false;
           }


### PR DESCRIPTION
## Summary
- add exchange-rate input to the key generator
- encode the exchange rate in the generated key
- add validation logic to decode the rate during login
- update login process to use the new validator

## Testing
- `npm test` *(fails: Admin API tests unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_687ab445cd988324a93e2075ee48b46b