### PR TITLE
Add raffle promotion overlay

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -2137,6 +2137,43 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       border-bottom: none;
     }
 
+    /* Raffle Overlay */
+    .raffle-options {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .raffle-option {
+      border: 1px solid var(--neutral-300);
+      border-radius: var(--radius-md);
+      overflow: hidden;
+      cursor: pointer;
+    }
+
+    .raffle-option.selected {
+      box-shadow: 0 0 0 2px var(--primary);
+    }
+
+    .raffle-option input {
+      display: none;
+    }
+
+    .raffle-video {
+      width: 100%;
+      height: 180px;
+      object-fit: cover;
+      display: block;
+    }
+
+    .raffle-option span {
+      display: block;
+      padding: 0.5rem;
+      font-size: 0.85rem;
+      text-align: center;
+      background: var(--neutral-100);
+    }
+
     /* Recharge Cancel Overlay */
     .recharge-cancel-overlay {
       position: fixed;
@@ -6605,6 +6642,45 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       <div class="points-history">
         <div class="points-history-title">Historial reciente</div>
         <ul class="points-history-list" id="points-history"></ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- Raffle Overlay -->
+  <div class="modal-overlay" id="promo-raffle-overlay" style="display:none;">
+    <div class="modal" style="max-width:500px;">
+      <div class="modal-title">Sorteo del Mes</div>
+      <div class="modal-subtitle" id="raffle-subtitle"></div>
+      <div class="raffle-options" id="raffle-selection">
+        <label class="raffle-option">
+          <input type="radio" name="raffle-phone" value="fold">
+          <video class="raffle-video" src="https://images.samsung.com/es/smartphones/galaxy-z-fold7/buy/03_Gallery/01_Animated_KV/Q7_Animated_KV_PC.mp4" autoplay loop muted playsinline></video>
+          <span>Samsung Galaxy Fold 7 – 1TB / 16GB RAM / Azul intenso</span>
+        </label>
+        <label class="raffle-option">
+          <input type="radio" name="raffle-phone" value="flip">
+          <video class="raffle-video" src="https://images.samsung.com/es/smartphones/galaxy-z-flip7/buy/03_Gallery/01_Animated_KV/B7_Animated_KV_PC.mp4" autoplay loop muted playsinline></video>
+          <span>Samsung Galaxy Flip 7 – 512GB / 12GB RAM / Azul intenso</span>
+        </label>
+        <button class="btn btn-primary" id="participate-btn" style="margin-top:1rem;" disabled>Participar</button>
+      </div>
+      <div id="raffle-info" style="display:none;text-align:center;">
+        <div style="margin-bottom:0.5rem;">Participas por: <strong id="raffle-selected"></strong></div>
+        <div style="margin-bottom:0.5rem;">Ticket <span id="raffle-ticket"></span></div>
+        <div>Sorteo en <span id="raffle-countdown"></span> días</div>
+        <button class="btn btn-primary" id="raffle-close" style="margin-top:1rem;">Cerrar</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Raffle Success Overlay -->
+  <div class="success-container" id="raffle-success-overlay" style="display:none;">
+    <div class="success-card">
+      <div class="success-checkmark"><i class="fas fa-check"></i></div>
+      <div class="success-title">¡Listo! Ya estás participando.</div>
+      <div class="success-message">Número de ticket <span id="raffle-success-ticket"></span><br>Te notificaremos si resultas ganador.</div>
+      <div class="success-actions">
+        <button class="btn btn-primary" id="raffle-success-close"><i class="fas fa-check"></i> Entendido</button>
       </div>
     </div>
   </div>
@@ -12881,8 +12957,12 @@ function setupLoginBlockOverlay() {
 
       if (promoNavBtn) {
         promoNavBtn.addEventListener('click', function() {
-          const modal = document.getElementById('coming-soon-modal');
-          if (modal) modal.style.display = 'flex';
+          if (window.openRaffleOverlay) {
+            window.openRaffleOverlay();
+          } else {
+            const overlay = document.getElementById('promo-raffle-overlay');
+            if (overlay) overlay.style.display = 'flex';
+          }
           resetInactivityTimer();
         });
       }
@@ -18520,6 +18600,7 @@ function checkTierProgressOverlay() {
       obs.observe(overlay,{attributes:true,attributeFilter:["style"]});
     });
   </script>
+  <script src="recargasorteo.js"></script>
   <script src="recargapoints.js"></script>
   <script src="language.js"></script>
   <script src="preload.js"></script>

--- a/public/recargasorteo.js
+++ b/public/recargasorteo.js
@@ -1,0 +1,113 @@
+'use strict';
+(function(){
+  const STORAGE_KEY = 'remeexRaffle';
+  const FOLD = 'fold';
+  const FLIP = 'flip';
+  function getRaffleEnd(){
+    const now = new Date();
+    const end = new Date(now.getFullYear(), now.getMonth()+2, 0, 23,59,59,999);
+    return end.getTime();
+  }
+  function load(){
+    try{
+      const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      if(data.end && Date.now() <= data.end){ return data; }
+    }catch(e){}
+    return {};
+  }
+  function save(data){
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }
+  function generateTicket(){
+    const num = Math.floor(Math.random()*900000)+100000;
+    return '#'+num.toLocaleString('de-DE');
+  }
+  function updateCountdown(end){
+    const el = document.getElementById('raffle-countdown');
+    if(!el) return;
+    const days = Math.max(0, Math.ceil((end - Date.now())/86400000));
+    el.textContent = days;
+  }
+  function showSelection(){
+    const selection=document.getElementById('raffle-selection');
+    const info=document.getElementById('raffle-info');
+    const btn=document.getElementById('participate-btn');
+    if(selection) selection.style.display='block';
+    if(info) info.style.display='none';
+    if(btn) btn.disabled=true;
+    document.querySelectorAll('.raffle-option').forEach(o=>{
+      o.classList.remove('selected');
+      const inp=o.querySelector('input');
+      if(inp) inp.checked=false;
+    });
+  }
+  function showInfo(data){
+    const selection=document.getElementById('raffle-selection');
+    const info=document.getElementById('raffle-info');
+    if(selection) selection.style.display='none';
+    if(info){
+      info.style.display='block';
+      const model=data.choice===FOLD?'Samsung Galaxy Fold 7':'Samsung Galaxy Flip 7';
+      const nameEl=document.getElementById('raffle-selected');
+      const ticketEl=document.getElementById('raffle-ticket');
+      if(nameEl) nameEl.textContent=model;
+      if(ticketEl) ticketEl.textContent=data.ticket;
+      updateCountdown(data.end);
+    }
+  }
+  function openOverlay(){
+    const overlay=document.getElementById('promo-raffle-overlay');
+    const subtitle=document.getElementById('raffle-subtitle');
+    const data=load();
+    const end=data.end||getRaffleEnd();
+    if(subtitle){
+      subtitle.textContent='Participa hasta '+new Date(end).toLocaleDateString('es-ES',{day:'numeric',month:'long',year:'numeric'});
+    }
+    if(data.choice){ showInfo(Object.assign({},data,{end})); }
+    else{ showSelection(); }
+    if(overlay) overlay.style.display='flex';
+  }
+  function closeOverlay(){
+    const overlay=document.getElementById('promo-raffle-overlay');
+    if(overlay) overlay.style.display='none';
+  }
+  function participate(){
+    const input=document.querySelector('.raffle-option input:checked');
+    if(!input) return;
+    const data={ end:getRaffleEnd(), choice:input.value, ticket:generateTicket() };
+    save(data);
+    closeOverlay();
+    const success=document.getElementById('raffle-success-overlay');
+    const ticketEl=document.getElementById('raffle-success-ticket');
+    if(ticketEl) ticketEl.textContent=data.ticket;
+    if(success){
+      success.style.display='flex';
+      if(typeof confetti==='function'){ confetti({particleCount:200,spread:80,origin:{y:0.6}}); }
+    }
+  }
+  function setup(){
+    const openBtn=document.getElementById('promo-nav-btn');
+    const closeBtn=document.getElementById('raffle-close');
+    const overlay=document.getElementById('promo-raffle-overlay');
+    const partBtn=document.getElementById('participate-btn');
+    const successClose=document.getElementById('raffle-success-close');
+    if(openBtn) openBtn.addEventListener('click',openOverlay);
+    if(closeBtn) closeBtn.addEventListener('click',closeOverlay);
+    if(overlay) overlay.addEventListener('click',e=>{ if(e.target===overlay) closeOverlay(); });
+    if(partBtn) partBtn.addEventListener('click',participate);
+    if(successClose) successClose.addEventListener('click',()=>{
+      const s=document.getElementById('raffle-success-overlay');
+      if(s) s.style.display='none';
+    });
+    document.querySelectorAll('.raffle-option input').forEach(inp=>{
+      inp.addEventListener('change',function(){
+        const opt=this.closest('.raffle-option');
+        document.querySelectorAll('.raffle-option').forEach(o=>o.classList.remove('selected'));
+        if(opt) opt.classList.add('selected');
+        if(partBtn) partBtn.disabled=false;
+      });
+    });
+  }
+  window.openRaffleOverlay=openOverlay;
+  document.addEventListener('DOMContentLoaded',setup);
+})();


### PR DESCRIPTION
## Summary
- enable promo raffle from settings
- add overlay markup for new monthly raffle
- style raffle overlay in-line with existing UI
- implement raffle logic in `recargasorteo.js`

## Testing
- `npm test` *(fails: Unauthorized errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ad43dacb08324875a23886fab87c2