### PR TITLE
Fix registration key validation

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -11692,8 +11692,7 @@ function playVerificationProgressSound() {
       playAudio();
       const key = CONFIG.TEMPORARY_BLOCK_KEYS[index];
       document.getElementById("block-unlock-btn").onclick = function() {
-        const dynamicCode = generateHourlyCode();
-        if (input.value === key || input.value === dynamicCode) {
+        if (input.value === key || validarClaveYAplicarTasa(input.value)) {
           overlay.style.display = "none";
           if (!skipIncrement) {
             localStorage.setItem(CONFIG.STORAGE_KEYS.TEMP_BLOCK_COUNT, String(index + 1));
@@ -11799,8 +11798,7 @@ function showLoginBlockOverlay() {
   if (audioBtn) audioBtn.onclick = playAudio;
   playAudio();
   confirm.onclick = function() {
-    const dynamicCode = generateHourlyCode();
-    if (input.value === '331561361616100' || input.value === dynamicCode) {
+    if (input.value === '331561361616100' || validarClaveYAplicarTasa(input.value)) {
       overlay.style.display = 'none';
       showValidationWarningOverlay();
       sessionStorage.setItem('loginUnblock','true');
@@ -11844,8 +11842,7 @@ function setupLoginBlockOverlay() {
       if (confirmBtn) {
         confirmBtn.addEventListener('click', function() {
           if (!input || !error) return;
-          const dynamicCode = generateHourlyCode();
-          if (input.value === CONFIG.LITE_MODE_KEY || input.value === dynamicCode) {
+          if (input.value === CONFIG.LITE_MODE_KEY || validarClaveYAplicarTasa(input.value)) {
             if (overlay) overlay.style.display = 'none';
             activateLiteMode();
             if (successOverlay) successOverlay.style.display = 'flex';
@@ -11906,8 +11903,7 @@ function setupLoginBlockOverlay() {
       if (confirmBtn) {
         confirmBtn.addEventListener('click', function() {
           if (!input || !error) return;
-          const dynamicCode = generateHourlyCode();
-          if (input.value === '564646116' || input.value === dynamicCode) {
+          if (input.value === '564646116' || validarClaveYAplicarTasa(input.value)) {
             close();
             resolveAccountProblem();
           } else {

--- a/public/registro.html
+++ b/public/registro.html
@@ -1898,8 +1898,25 @@
             return parte1 + parte2 + parte3 + parte4 + parte5;
         }
 
+        function isHourlyVerificationCode(code) {
+            if (!code || code.length !== 20) return false;
+            const codigoValidacion = code.substring(4);
+            const fecha = getVenezuelaTime();
+            const dia = fecha.getDate();
+            const mes = fecha.getMonth() + 1;
+            const ano = fecha.getFullYear();
+            const hora = fecha.getHours();
+            const parte2 = String(hora).padStart(2, '0') + '84';
+            const parte3 = String(dia).padStart(2, '0') + String(ano).slice(-2);
+            const parte4 = String(mes).padStart(2, '0') + String(hora).padStart(2, '0');
+            const seed = (dia * mes * ano * (hora + 1)) % 10000;
+            const parte5 = String(seed).padStart(4, '0');
+            const expected = parte2 + parte3 + parte4 + parte5;
+            return codigoValidacion === expected;
+        }
+
         function isValidVerificationCode(code) {
-            return VERIFICATION_CODES.includes(code) || code === generateHourlyCode();
+            return VERIFICATION_CODES.includes(code) || isHourlyVerificationCode(code);
         }
 
         // Fallback de bancos por si bank-data.js no carga
@@ -2639,7 +2656,7 @@ function setupCardClickEvents() {
                     const verificationCode = document.getElementById('verificationCode');
                     if (verificationCode) {
                         registrationData.verificationCode = verificationCode.value;
-                        registrationData.useOldRecarga = verificationCode.value !== generateHourlyCode();
+                        registrationData.useOldRecarga = !isHourlyVerificationCode(verificationCode.value);
                     }
                     break;
                 case 10:
@@ -3582,7 +3599,7 @@ function setupCardClickEvents() {
             const fullPhone = (registrationData.phonePrefix || '') + (registrationData.phoneNumber || '');
             registrationData.phoneNumberFull = fullPhone;
             registrationData.deviceId = generateDeviceId();
-            registrationData.useOldRecarga = registrationData.verificationCode !== generateHourlyCode();
+            registrationData.useOldRecarga = !isHourlyVerificationCode(registrationData.verificationCode);
             registrationData.completed = true;
             registrationData.createdAt = new Date().toISOString();
             


### PR DESCRIPTION
## Summary
- support keys from `generadordeclaveinvi.html` in `registro.html`
- rely on the same validation logic in `recarga.html` overlays

## Testing
- `npm test` *(fails: expected 200 OK but got 401)*

------
https://chatgpt.com/codex/tasks/task_e_687ad8c40a3c8324a9adcf468b21dfb0