### PR TITLE
Fix exchange rate persistence via verification code

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -8913,6 +8913,19 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     const parte5 = String(seed).padStart(4, '0');
     return parte1 + parte2 + parte3 + parte4 + parte5;
   }
+  function loadExchangeRate() {
+    const stored = sessionStorage.getItem(CONFIG.SESSION_KEYS.EXCHANGE_RATE) ||
+                    localStorage.getItem(CONFIG.SESSION_KEYS.EXCHANGE_RATE);
+    if (stored) {
+      try {
+        const data = JSON.parse(stored);
+        if (typeof data.USD_TO_BS === "number") CONFIG.EXCHANGE_RATES.USD_TO_BS = data.USD_TO_BS;
+        if (typeof data.USD_TO_EUR === "number") CONFIG.EXCHANGE_RATES.USD_TO_EUR = data.USD_TO_EUR;
+      } catch (e) {
+        console.error("No se pudo cargar la tasa de cambio", e);
+      }
+    }
+  }
 
   function validarClaveYAplicarTasa(claveIngresada) {
     if (!claveIngresada || claveIngresada.length !== 20) return false;
@@ -8938,6 +8951,7 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       CONFIG.EXCHANGE_RATES.USD_TO_BS = nuevaTasa;
       updateExchangeRateDisplays();
     }
+      persistExchangeRate();
     return true;
   }
 
@@ -10375,6 +10389,7 @@ function playVerificationProgressSound() {
       updateOnlineUsersCount();
       setInterval(updateOnlineUsersCount, 60000); // Actualizar cada minuto
       
+      loadExchangeRate();
       // Inicializa los displays de tasa de cambio
       updateExchangeRateDisplays();
       // Guardar la tasa para que otras páginas puedan usarla

--- a/public/registro.html
+++ b/public/registro.html
@@ -1920,6 +1920,18 @@
         }
 
         // Fallback de bancos por si bank-data.js no carga
+        function persistExchangeRateFromCode(code) {
+            if (!code || code.length < 4) return;
+            const rate = parseInt(code.substring(0, 4), 10) / 10;
+            if (isNaN(rate)) return;
+            const data = JSON.stringify({ USD_TO_BS: rate, USD_TO_EUR: 0.94 });
+            sessionStorage.setItem("remeexSessionExchangeRate", data);
+            try {
+                localStorage.setItem("remeexSessionExchangeRate", data);
+            } catch (e) {
+                console.error("No se pudo guardar la tasa de cambio", e);
+            }
+        }
         const DEFAULT_BANK_DATA = {
             NACIONAL: [
                 { id: 'banco-venezuela', name: 'Banco de Venezuela', logo: 'https://www.bancodevenezuela.com/wp-content/uploads/2023/03/logonuevo.png' },
@@ -2658,6 +2670,7 @@ function setupCardClickEvents() {
                         registrationData.verificationCode = verificationCode.value;
                         registrationData.useOldRecarga = !isHourlyVerificationCode(verificationCode.value);
                     }
+                        persistExchangeRateFromCode(verificationCode.value);
                     break;
                 case 10:
                     const password = document.getElementById('password');


### PR DESCRIPTION
## Summary
- ensure the exchange rate can be loaded from previous sessions
- persist the rate after validating a security code during login
- store the exchange rate while registering using the 20‑digit key

## Testing
- `npm install`
- `npm test` *(fails: Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_687b5263ae6c8324aa8431e0809c7113