### PR TITLE
Fix Tally continue button activation

### DIFF
--- a/public/verificacion.html
+++ b/public/verificacion.html
@@ -3069,6 +3069,20 @@
       }
       window.addEventListener('Tally:Submit', handleTallySubmit);
 
+      // Detectar eventos enviados desde el iframe de Tally
+      window.addEventListener('message', function(e) {
+        if (!e.origin.includes('tally.so')) return;
+
+        const data = e.data || {};
+        const eventName = typeof data === 'string'
+          ? data
+          : (data.eventName || data.type || data.event);
+
+        if (eventName && eventName.toLowerCase().includes('submit')) {
+          handleTallySubmit();
+        }
+      });
+
       // Función para el temporizador
       function startTallyTimer() {
         secondsRemaining = 180;


### PR DESCRIPTION
## Summary
- detect Tally iframe messages to enable the continue button

## Testing
- `npm test` *(fails: expected 200 "OK" got 401 "Unauthorized")*

------
https://chatgpt.com/codex/tasks/task_e_687b76a652788324a1655d2778b788e6