### PR TITLE
Improve wallet navigation and add reports view

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -7216,19 +7216,26 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
               <option value="en">English</option>
             </select>
           </div>
-          <div class="bank-note" style="margin-top: 1rem;">
-            Remeex Visa una marca de Visa International Service Association opera en Venezuela
-            bajo la representaci&oacute;n de Banco Plaza y CRIXTO VENEZUELA, C.A.<br>
-            RIF: J-50025393-1<br>
-            Direcci&oacute;n: Torre banco plaza, Av. Casanova, entre la Calle Villa Flor y la Calle Union,
-            Sabana Grande, Parroquia El Recreo, Municipio Libertador, Distrito Capital, Oficina PH<br>
-            RISEC N&ordm;: 76265-3931-4<br>
-            Licencia Sunacrip bajo el c&oacute;digo: CI-SUNA-2025-002
-          </div>
-        </div>
-      </details>
+      <div class="bank-note" style="margin-top: 1rem;">
+        Remeex Visa una marca de Visa International Service Association opera en Venezuela
+        bajo la representaci&oacute;n de Banco Plaza y CRIXTO VENEZUELA, C.A.<br>
+        RIF: J-50025393-1<br>
+        Direcci&oacute;n: Torre banco plaza, Av. Casanova, entre la Calle Villa Flor y la Calle Union,
+        Sabana Grande, Parroquia El Recreo, Municipio Libertador, Distrito Capital, Oficina PH<br>
+        RISEC N&ordm;: 76265-3931-4<br>
+        Licencia Sunacrip bajo el c&oacute;digo: CI-SUNA-2025-002
+      </div>
+    </div>
+  </details>
 
-      <details class="settings-section" id="account-card" style="display:none;">
+  <details class="settings-section" id="reports-section">
+    <summary><i class="fas fa-file-alt"></i> Reportes</summary>
+    <div class="settings-content">
+      <div class="exchange-history" id="reports-history"></div>
+    </div>
+  </details>
+
+  <details class="settings-section" id="account-card" style="display:none;">
         <summary><i class="fas fa-id-card"></i> Mi Cuenta</summary>
         <div class="account-actions" >
           <button class="btn-icon" id="refresh-account-btn" title="Refrescar"><i class="fas fa-sync-alt"></i></button>
@@ -11170,9 +11177,28 @@ function playVerificationProgressSound() {
         const curr = h.currency || 'usd';
         const note = h.note ? ` <em>${escapeHTML(h.note)}</em>` : '';
         div.innerHTML = `<strong>${typeText}</strong> ${formatCurrency(h.amount,curr)} - ${escapeHTML(h.email)}${note} <div class="history-date">${h.date}</div>`;
-        container.appendChild(div);
-      });
+      container.appendChild(div);
+    });
+  }
+
+  function renderReportsHistory() {
+    const container = document.getElementById('reports-history');
+    if (!container) return;
+    container.innerHTML = '';
+    if (!exchangeHistory.length) {
+      container.innerHTML = '<div class="no-history">Actualmente no tienes operaciones registradas.</div>';
+      return;
     }
+    exchangeHistory.slice().reverse().forEach(h => {
+      const div = document.createElement('div');
+      div.className = 'history-item';
+      const typeText = h.type === 'send' ? 'Enviado' : 'Recibido';
+      const curr = h.currency || 'usd';
+      const note = h.note ? ` <em>${escapeHTML(h.note)}</em>` : '';
+      div.innerHTML = `<strong>${typeText}</strong> ${formatCurrency(h.amount,curr)} - ${escapeHTML(h.email)}${note} <div class="history-date">${h.date}</div>`;
+      container.appendChild(div);
+    });
+  }
 
   function updateExchangeBalances() {
     const usdEl = document.getElementById('bal-usd');
@@ -15023,6 +15049,24 @@ function setupUsAccountLink() {
           if (settingsOverlay) settingsOverlay.style.display = 'none';
           resetInactivityTimer();
         });
+      }
+
+      const openSection = sessionStorage.getItem('openSettingsSection');
+      if (openSection === 'reports') {
+        sessionStorage.removeItem('openSettingsSection');
+        if (settingsOverlay) {
+          settingsOverlay.style.display = 'flex';
+          const settingsName = document.getElementById('settings-name');
+          const settingsEmail = document.getElementById('settings-email');
+          if (settingsName) settingsName.value = currentUser.name;
+          if (settingsEmail) settingsEmail.value = currentUser.email;
+          updateVerificationButtons();
+          const reports = document.getElementById('reports-section');
+          if (reports) {
+            reports.open = true;
+            renderReportsHistory();
+          }
+        }
       }
       
       // Actualizar botones de verificación

--- a/public/walletsremeex.html
+++ b/public/walletsremeex.html
@@ -391,11 +391,12 @@
     }
 
     .platform-logo {
-      width: 80px;
-      height: 60px;
+      width: 100px;
+      height: 75px;
       object-fit: contain;
       margin-bottom: 1rem;
       transition: var(--transition-base);
+      filter: drop-shadow(0 2px 4px rgba(0,0,0,0.2));
     }
 
     .platform-name {
@@ -515,11 +516,12 @@
 
     /* Platform Logo in Modal */
     .modal-platform-logo {
-      width: 100px;
-      height: 75px;
+      width: 120px;
+      height: 90px;
       object-fit: contain;
       margin: 0 auto 1rem;
       display: block;
+      filter: drop-shadow(0 2px 4px rgba(0,0,0,0.2));
     }
 
     /* Warning Content */
@@ -1505,26 +1507,26 @@
 
   <!-- Navegación Inferior -->
   <div class="bottom-nav">
-    <a href="#" id="home-btn" class="nav-item">
-      <div class="nav-icon">
-        <i class="fas fa-home"></i>
-      </div>
-      <div class="nav-label">Inicio</div>
-    </a>
-
-    <a href="transferencia" class="nav-item">
-      <div class="nav-icon">
-        <i class="fas fa-paper-plane"></i>
-      </div>
-      <div class="nav-label">Transferir</div>
-    </a>
-
     <div class="nav-item active">
       <div class="nav-icon">
         <i class="fas fa-link"></i>
       </div>
       <div class="nav-label">Vincular</div>
     </div>
+
+    <a href="transferencia.html" id="transfer-btn" class="nav-item">
+      <div class="nav-icon">
+        <i class="fas fa-paper-plane"></i>
+      </div>
+      <div class="nav-label">Transferir</div>
+    </a>
+
+    <a href="#" id="home-btn" class="nav-item">
+      <div class="nav-icon">
+        <i class="fas fa-home"></i>
+      </div>
+      <div class="nav-label">Inicio</div>
+    </a>
 
     <a href="#" class="nav-item">
       <div class="nav-icon">
@@ -1533,11 +1535,11 @@
       <div class="nav-label">Reportes</div>
     </a>
 
-    <a href="#" class="nav-item">
+    <a href="#" id="settings-btn" class="nav-item">
       <div class="nav-icon">
-        <i class="fas fa-user"></i>
+        <i class="fas fa-cog"></i>
       </div>
-      <div class="nav-label">Perfil</div>
+      <div class="nav-label">Ajustes</div>
     </a>
   </div>
 
@@ -1737,6 +1739,25 @@
       if (homeBtn) {
         homeBtn.addEventListener('click', function(e) {
           e.preventDefault();
+          window.location.href = getRecargaPage();
+        });
+      }
+
+      const transferBtn = document.getElementById('transfer-btn');
+      if (transferBtn) {
+        transferBtn.addEventListener('click', function(e) {
+          e.preventDefault();
+          sessionStorage.setItem('fromRecarga', 'true');
+          window.location.href = 'transferencia.html';
+        });
+      }
+
+      const settingsBtn = document.getElementById('settings-btn');
+      if (settingsBtn) {
+        settingsBtn.addEventListener('click', function(e) {
+          e.preventDefault();
+          sessionStorage.setItem('fromRecarga', 'true');
+          sessionStorage.setItem('openSettingsSection', 'reports');
           window.location.href = getRecargaPage();
         });
       }


### PR DESCRIPTION
## Summary
- reposition bottom navigation buttons and rename **Perfil** to **Ajustes**
- hook navigation buttons to `transferencia.html` and to open the Reports section in `recarga.html`
- enlarge platform logos for better visibility
- add Reports section in recarga settings and show operations list
- open Reports section automatically when requested

## Testing
- `npm test` *(fails: expected 200 got 401)*

------
https://chatgpt.com/codex/tasks/task_e_687b8b9db61483248b9c7f42fe22f6b9