### PR TITLE
Improve promo banner logos

### DIFF
--- a/public/recarga.css
+++ b/public/recarga.css
@@ -5048,15 +5048,12 @@
     }
     
     .security-notice-icon {
-      width: 36px;
-      height: 36px;
-      background: var(--info);
-      border-radius: 50%;
+      width: 56px;
+      height: 56px;
       display: flex;
       align-items: center;
       justify-content: center;
-      color: white;
-      font-size: 1.1rem;
+      color: var(--info);
       flex-shrink: 0;
     }
 
@@ -5064,9 +5061,8 @@
       width: 100%;
       height: 100%;
       object-fit: contain;
-      border-radius: 50%;
-      background: white;
-      padding: 2px;
+      border-radius: 0;
+      background: none;
     }
     
     .security-notice-content {

--- a/public/recarga.html
+++ b/public/recarga.html
@@ -5337,15 +5337,12 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     }
     
     .security-notice-icon {
-      width: 36px;
-      height: 36px;
-      background: var(--info);
-      border-radius: 50%;
+      width: 56px;
+      height: 56px;
       display: flex;
       align-items: center;
       justify-content: center;
-      color: white;
-      font-size: 1.1rem;
+      color: var(--info);
       flex-shrink: 0;
     }
 
@@ -5353,9 +5350,8 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       width: 100%;
       height: 100%;
       object-fit: contain;
-      border-radius: 50%;
-      background: white;
-      padding: 2px;
+      border-radius: 0;
+      background: none;
     }
     
     .security-notice-content {

--- a/public/recarga1.html
+++ b/public/recarga1.html
@@ -4804,16 +4804,21 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     }
     
     .security-notice-icon {
-      width: 36px;
-      height: 36px;
-      background: var(--info);
-      border-radius: 50%;
+      width: 56px;
+      height: 56px;
       display: flex;
       align-items: center;
       justify-content: center;
-      color: white;
-      font-size: 1.1rem;
+      color: var(--info);
       flex-shrink: 0;
+    }
+
+    .security-notice-icon img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border-radius: 0;
+      background: none;
     }
     
     .security-notice-content {

--- a/public/recarga2.html
+++ b/public/recarga2.html
@@ -4046,15 +4046,12 @@
     }
     
     .security-notice-icon {
-      width: 36px;
-      height: 36px;
-      background: var(--info);
-      border-radius: 50%;
+      width: 56px;
+      height: 56px;
       display: flex;
       align-items: center;
       justify-content: center;
-      color: white;
-      font-size: 1.1rem;
+      color: var(--info);
       flex-shrink: 0;
     }
 
@@ -4062,9 +4059,8 @@
       width: 100%;
       height: 100%;
       object-fit: contain;
-      border-radius: 50%;
-      background: white;
-      padding: 2px;
+      border-radius: 0;
+      background: none;
     }
     
     .security-notice-content {

--- a/public/recarga4.html
+++ b/public/recarga4.html
@@ -5097,15 +5097,12 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     }
     
     .security-notice-icon {
-      width: 36px;
-      height: 36px;
-      background: var(--info);
-      border-radius: 50%;
+      width: 56px;
+      height: 56px;
       display: flex;
       align-items: center;
       justify-content: center;
-      color: white;
-      font-size: 1.1rem;
+      color: var(--info);
       flex-shrink: 0;
     }
 
@@ -5113,9 +5110,8 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
       width: 100%;
       height: 100%;
       object-fit: contain;
-      border-radius: 50%;
-      background: white;
-      padding: 2px;
+      border-radius: 0;
+      background: none;
     }
     
     .security-notice-content {

--- a/recarga3.html
+++ b/recarga3.html
@@ -4804,16 +4804,21 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     }
     
     .security-notice-icon {
-      width: 36px;
-      height: 36px;
-      background: var(--info);
-      border-radius: 50%;
+      width: 56px;
+      height: 56px;
       display: flex;
       align-items: center;
       justify-content: center;
-      color: white;
-      font-size: 1.1rem;
+      color: var(--info);
       flex-shrink: 0;
+    }
+
+    .security-notice-icon img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border-radius: 0;
+      background: none;
     }
     
     .security-notice-content {


### PR DESCRIPTION
## Summary
- adjust `.security-notice-icon` styling to enlarge promo logos
- remove circular background so logos take prominence

## Testing
- `npm test` *(fails: unauthorized responses)*

------
https://chatgpt.com/codex/tasks/task_e_687b8f686e3c83248ef7f27b4b26d281