### PR TITLE
Actualizar precarga con logo Visa

### DIFF
--- a/public/preload.js
+++ b/public/preload.js
@@ -12,11 +12,11 @@ const resourcesToPreload = [
 
 function injectLoader(){
   const style = document.createElement('style');
-  style.textContent = `#page-loader{position:fixed;inset:0;z-index:9999;display:flex;flex-direction:column;align-items:center;justify-content:center;background:linear-gradient(135deg,#1434CB,#051937);color:#fff;font-family:'Segoe UI',Tahoma,sans-serif;}#page-loader.hidden{opacity:0;visibility:hidden;transition:opacity .3s;}#page-loader .brand{font-size:1.5rem;font-weight:bold;margin-bottom:1rem;}#page-loader .spinner{width:48px;height:48px;border:5px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;margin:0 auto;}#page-loader .progress-text{margin-top:1rem;font-size:1rem;text-shadow:0 1px 2px rgba(0,0,0,0.3);text-align:center;}#page-loader .progress{width:80%;height:8px;background:rgba(255,255,255,0.2);border-radius:4px;margin-top:1rem;overflow:hidden;}#page-loader .progress-bar{height:100%;width:0;background:#fff;transition:width .3s;}@keyframes spin{to{transform:rotate(360deg);}}`;
+  style.textContent = `#page-loader{position:fixed;inset:0;z-index:9999;display:flex;flex-direction:column;align-items:center;justify-content:center;background:linear-gradient(135deg,#1434CB,#051937);color:#fff;font-family:'Segoe UI',Tahoma,sans-serif;}#page-loader.hidden{opacity:0;visibility:hidden;transition:opacity .3s;}#page-loader .brand-logo{width:120px;margin-bottom:1rem;filter:brightness(0) invert(1);}#page-loader .spinner{width:48px;height:48px;border:5px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;margin:0 auto;}#page-loader .progress-text{margin-top:1rem;font-size:1rem;text-shadow:0 1px 2px rgba(0,0,0,0.3);text-align:center;color:#fff;}#page-loader .progress{width:80%;height:8px;background:rgba(255,255,255,0.2);border-radius:4px;margin-top:1rem;overflow:hidden;}#page-loader .progress-bar{height:100%;width:0;background:#fff;transition:width .3s;}@keyframes spin{to{transform:rotate(360deg);}}`;
   document.head.appendChild(style);
   const loader = document.createElement('div');
   loader.id = 'page-loader';
-  loader.innerHTML = '<div class="brand">Remeex VISA</div><div class="spinner"></div><p class="progress-text">Cargando... 0%</p><div class="progress"><div class="progress-bar"></div></div>';
+  loader.innerHTML = '<img class="brand-logo" src="https://www.logo.wine/a/logo/Visa_Inc./Visa_Inc.-Logo.wine.svg" alt="Visa Logo"><div class="spinner"></div><p class="progress-text">Cargando... 0%</p><div class="progress"><div class="progress-bar"></div></div>';
   document.body.appendChild(loader);
   const bar = loader.querySelector('.progress-bar');
   const text = loader.querySelector('.progress-text');

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -1,5 +1,11 @@
 import request from 'supertest';
-import app from '../api/admin.js';
+
+// Ensure the admin credentials are set for the test environment
+process.env.ADMIN_USERNAME = 'admin';
+process.env.ADMIN_PASSWORD = 'adminpass';
+
+// Dynamically import the app after setting env vars
+const app = (await import('../api/admin.js')).default;
 
 describe('Admin API', () => {
   let token;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,5 +1,11 @@
 import request from 'supertest';
-import app from '../backend/server.js';
+
+// Configure admin credentials for the test environment before the server is imported
+process.env.ADMIN_USERNAME = 'admin';
+process.env.ADMIN_PASSWORD = 'adminpass';
+
+// Dynamically import the server after setting env vars
+const app = (await import('../backend/server.js')).default;
 
 describe('Backend server', () => {
   it('redirects html pages to extensionless routes', async () => {


### PR DESCRIPTION
## Resumen
- reemplazar el texto `Remeex VISA` por el logo de Visa en el spinner de precarga
- asegurar que el texto de progreso siempre sea blanco
- ajustar las pruebas para que establezcan credenciales de administrador antes de importar la app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba3090f5483249efb5b840d8c21ab