### PR TITLE
Add additional wallet logos

### DIFF
--- a/public/walletsremeex.html
+++ b/public/walletsremeex.html
@@ -1340,6 +1340,253 @@
               Disponible
             </span>
           </div>
+
+          <!-- Taptap Send -->
+          <div class="platform-card" data-platform="taptapsend"
+               data-logo="https://images.seeklogo.com/logo-png/50/1/taptap-send-logo-png_seeklogo-500619.png"
+               data-name="Taptap Send">
+            <img src="https://images.seeklogo.com/logo-png/50/1/taptap-send-logo-png_seeklogo-500619.png" alt="Taptap Send" class="platform-logo">
+            <h3 class="platform-name">Taptap Send</h3>
+            <p class="platform-description">Envíos de dinero rápidos a familiares y amigos.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Zelle -->
+          <div class="platform-card" data-platform="zelle"
+               data-logo="https://www.logo.wine/a/logo/Zelle_(payment_service)/Zelle_(payment_service)-Logo.wine.svg"
+               data-name="Zelle">
+            <img src="https://www.logo.wine/a/logo/Zelle_(payment_service)/Zelle_(payment_service)-Logo.wine.svg" alt="Zelle" class="platform-logo">
+            <h3 class="platform-name">Zelle</h3>
+            <p class="platform-description">Pagos y transferencias entre bancos en EE. UU.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Apple Pay -->
+          <div class="platform-card" data-platform="applepay"
+               data-logo="https://www.logo.wine/a/logo/Apple_Pay/Apple_Pay-Logo.wine.svg"
+               data-name="Apple Pay">
+            <img src="https://www.logo.wine/a/logo/Apple_Pay/Apple_Pay-Logo.wine.svg" alt="Apple Pay" class="platform-logo">
+            <h3 class="platform-name">Apple Pay</h3>
+            <p class="platform-description">Realiza compras seguras desde tus dispositivos Apple.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Amazon Pay -->
+          <div class="platform-card" data-platform="amazonpay"
+               data-logo="https://www.logo.wine/a/logo/Amazon_Pay/Amazon_Pay-Logo.wine.svg"
+               data-name="Amazon Pay">
+            <img src="https://www.logo.wine/a/logo/Amazon_Pay/Amazon_Pay-Logo.wine.svg" alt="Amazon Pay" class="platform-logo">
+            <h3 class="platform-name">Amazon Pay</h3>
+            <p class="platform-description">Paga de forma rápida y segura con tu cuenta de Amazon.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Alipay -->
+          <div class="platform-card" data-platform="alipay"
+               data-logo="https://www.logo.wine/a/logo/Alipay/Alipay-Logo.wine.svg"
+               data-name="Alipay">
+            <img src="https://www.logo.wine/a/logo/Alipay/Alipay-Logo.wine.svg" alt="Alipay" class="platform-logo">
+            <h3 class="platform-name">Alipay</h3>
+            <p class="platform-description">La plataforma de pagos más popular de Asia.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Payoneer -->
+          <div class="platform-card" data-platform="payoneer"
+               data-logo="https://www.logo.wine/a/logo/Payoneer/Payoneer-Logo.wine.svg"
+               data-name="Payoneer">
+            <img src="https://www.logo.wine/a/logo/Payoneer/Payoneer-Logo.wine.svg" alt="Payoneer" class="platform-logo">
+            <h3 class="platform-name">Payoneer</h3>
+            <p class="platform-description">Pagos internacionales para freelancers y negocios.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- HSBC -->
+          <div class="platform-card" data-platform="hsbc"
+               data-logo="https://www.logo.wine/a/logo/HSBC/HSBC-Logo.wine.svg"
+               data-name="HSBC">
+            <img src="https://www.logo.wine/a/logo/HSBC/HSBC-Logo.wine.svg" alt="HSBC" class="platform-logo">
+            <h3 class="platform-name">HSBC</h3>
+            <p class="platform-description">Conecta con tus cuentas globales de HSBC.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Deutsche Bank -->
+          <div class="platform-card" data-platform="deutschebank"
+               data-logo="https://www.logo.wine/a/logo/Deutsche_Bank/Deutsche_Bank-Logo.wine.svg"
+               data-name="Deutsche Bank">
+            <img src="https://www.logo.wine/a/logo/Deutsche_Bank/Deutsche_Bank-Logo.wine.svg" alt="Deutsche Bank" class="platform-logo">
+            <h3 class="platform-name">Deutsche Bank</h3>
+            <p class="platform-description">Servicios financieros de uno de los bancos más grandes de Europa.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Bank of America -->
+          <div class="platform-card" data-platform="bankofamerica"
+               data-logo="https://www.logo.wine/a/logo/Bank_of_America/Bank_of_America-Logo.wine.svg"
+               data-name="Bank of America">
+            <img src="https://www.logo.wine/a/logo/Bank_of_America/Bank_of_America-Logo.wine.svg" alt="Bank of America" class="platform-logo">
+            <h3 class="platform-name">Bank of America</h3>
+            <p class="platform-description">Integra tus cuentas de Bank of America de forma segura.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Citigroup -->
+          <div class="platform-card" data-platform="citigroup"
+               data-logo="https://www.logo.wine/a/logo/Citigroup/Citigroup-Logo.wine.svg"
+               data-name="Citigroup">
+            <img src="https://www.logo.wine/a/logo/Citigroup/Citigroup-Logo.wine.svg" alt="Citigroup" class="platform-logo">
+            <h3 class="platform-name">Citigroup</h3>
+            <p class="platform-description">Accede a los servicios globales de Citi.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Revolut -->
+          <div class="platform-card" data-platform="revolut"
+               data-logo="https://www.logo.wine/a/logo/Revolut/Revolut-Logo.wine.svg"
+               data-name="Revolut">
+            <img src="https://www.logo.wine/a/logo/Revolut/Revolut-Logo.wine.svg" alt="Revolut" class="platform-logo">
+            <h3 class="platform-name">Revolut</h3>
+            <p class="platform-description">Banca digital moderna y transferencias internacionales.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- TD Ameritrade -->
+          <div class="platform-card" data-platform="tdameritrade"
+               data-logo="https://www.logo.wine/a/logo/TD_Ameritrade/TD_Ameritrade-Logo.wine.svg"
+               data-name="TD Ameritrade">
+            <img src="https://www.logo.wine/a/logo/TD_Ameritrade/TD_Ameritrade-Logo.wine.svg" alt="TD Ameritrade" class="platform-logo">
+            <h3 class="platform-name">TD Ameritrade</h3>
+            <p class="platform-description">Invierte y gestiona tu portafolio con TD Ameritrade.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Chase Bank -->
+          <div class="platform-card" data-platform="chase"
+               data-logo="https://www.logo.wine/a/logo/Chase_Bank/Chase_Bank-Logo.wine.svg"
+               data-name="Chase Bank">
+            <img src="https://www.logo.wine/a/logo/Chase_Bank/Chase_Bank-Logo.wine.svg" alt="Chase Bank" class="platform-logo">
+            <h3 class="platform-name">Chase Bank</h3>
+            <p class="platform-description">Conecta tus cuentas del banco Chase fácilmente.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Binance -->
+          <div class="platform-card" data-platform="binanceexchange"
+               data-logo="https://www.logo.wine/a/logo/Binance/Binance-Logo.wine.svg"
+               data-name="Binance">
+            <img src="https://www.logo.wine/a/logo/Binance/Binance-Logo.wine.svg" alt="Binance" class="platform-logo">
+            <h3 class="platform-name">Binance</h3>
+            <p class="platform-description">Accede al mayor exchange de criptomonedas.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Santander Bank -->
+          <div class="platform-card" data-platform="santander"
+               data-logo="https://www.logo.wine/a/logo/Santander_Bank/Santander_Bank-Logo.wine.svg"
+               data-name="Santander Bank">
+            <img src="https://www.logo.wine/a/logo/Santander_Bank/Santander_Bank-Logo.wine.svg" alt="Santander Bank" class="platform-logo">
+            <h3 class="platform-name">Santander Bank</h3>
+            <p class="platform-description">Servicios bancarios internacionales de Santander.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- N26 -->
+          <div class="platform-card" data-platform="n26"
+               data-logo="https://www.logo.wine/a/logo/N26_(bank)/N26_(bank)-Logo.wine.svg"
+               data-name="N26">
+            <img src="https://www.logo.wine/a/logo/N26_(bank)/N26_(bank)-Logo.wine.svg" alt="N26" class="platform-logo">
+            <h3 class="platform-name">N26</h3>
+            <p class="platform-description">Banca móvil europea moderna y flexible.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Coinbase -->
+          <div class="platform-card" data-platform="coinbase"
+               data-logo="https://www.logo.wine/a/logo/Coinbase/Coinbase-Logo.wine.svg"
+               data-name="Coinbase">
+            <img src="https://www.logo.wine/a/logo/Coinbase/Coinbase-Logo.wine.svg" alt="Coinbase" class="platform-logo">
+            <h3 class="platform-name">Coinbase</h3>
+            <p class="platform-description">Compra y vende criptomonedas con Coinbase.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- BBVA USA -->
+          <div class="platform-card" data-platform="bbvausa"
+               data-logo="https://www.logo.wine/a/logo/BBVA_USA/BBVA_USA-Logo.wine.svg"
+               data-name="BBVA USA">
+            <img src="https://www.logo.wine/a/logo/BBVA_USA/BBVA_USA-Logo.wine.svg" alt="BBVA USA" class="platform-logo">
+            <h3 class="platform-name">BBVA USA</h3>
+            <p class="platform-description">Opera con tus cuentas de BBVA en Estados Unidos.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
+
+          <!-- Virgin Money UK -->
+          <div class="platform-card" data-platform="virginmoneyuk"
+               data-logo="https://www.logo.wine/a/logo/Virgin_Money_UK/Virgin_Money_UK-Logo.wine.svg"
+               data-name="Virgin Money UK">
+            <img src="https://www.logo.wine/a/logo/Virgin_Money_UK/Virgin_Money_UK-Logo.wine.svg" alt="Virgin Money UK" class="platform-logo">
+            <h3 class="platform-name">Virgin Money UK</h3>
+            <p class="platform-description">Soluciones financieras innovadoras en el Reino Unido.</p>
+            <span class="platform-status available">
+              <i class="fas fa-check-circle"></i>
+              Disponible
+            </span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- expand the list of available platforms in `walletsremeex.html`
- include logos for providers such as Taptap Send, Zelle, Apple Pay, Amazon Pay, Alipay, Payoneer and several international banks

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ba8e52a0483248b9a21bc0d264fbf