### PR TITLE
Fix Tally form spacing

### DIFF
--- a/public/verificacion.html
+++ b/public/verificacion.html
@@ -1337,8 +1337,9 @@
 
     .tally-iframe-container {
       flex: 1;
-      overflow: hidden;
+      overflow: auto;
       background: #f5f5f5;
+      padding-bottom: 10vh; /* Espacio extra para que no se solape con la barra fija */
     }
 
     .tally-iframe-container iframe {
@@ -1612,6 +1613,11 @@
 
       .tally-modal iframe {
         height: 60vh;
+      }
+
+      .tally-iframe-container {
+        padding-bottom: 10vh;
+        overflow: auto;
       }
 
       .tally-icon {


### PR DESCRIPTION
## Summary
- tweak Tally form iframe container to avoid overlap with fixed footer
- keep spacing responsive on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bbf7f85c48324a26c624c3d0592d7