### PR TITLE
Fix redirect from wallets settings

### DIFF
--- a/public/walletsremeex.html
+++ b/public/walletsremeex.html
@@ -1946,11 +1946,11 @@
 
       if (goToSettings) {
         goToSettings.addEventListener('click', () => {
-          // Aquí puedes redirigir a la página de ajustes
           showToast('info', 'Redirigiendo', 'Te llevamos a la sección de ajustes...');
           setTimeout(() => {
-            // window.location.href = 'ajustes.html#seguridad';
-            twofaModal.style.display = 'none';
+            sessionStorage.setItem('fromRecarga', 'true');
+            sessionStorage.setItem('openSettingsSection', 'reports');
+            window.location.href = getRecargaPage();
           }, 1500);
         });
       }


### PR DESCRIPTION
## Summary
- redirect to home when clicking 'Ir a Ajustes' in wallets page
- include session values so recarga opens on settings overlay

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bcde5fbcc83248f3f0d4c87610370