### PR TITLE
Add raffle instructions to recarga page

### DIFF
--- a/public/recarga.html
+++ b/public/recarga.html
@@ -6733,6 +6733,7 @@ if (typeof confetti === "undefined") { window.confetti = function(){}; }
     <div class="modal" style="max-width:500px;">
       <div class="modal-title">Sorteo del Mes</div>
       <div class="modal-subtitle" id="raffle-subtitle"></div>
+      <div class="modal-subtitle">Selecciona uno de los dos modelos para participar:</div>
       <div class="raffle-options" id="raffle-selection">
         <label class="raffle-option">
           <input type="radio" name="raffle-phone" value="fold">


### PR DESCRIPTION
## Summary
- clarify raffle choice instructions in `recarga.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bcf3f5f508324b2c1284ed2e57618